### PR TITLE
Friendlier 401 screen

### DIFF
--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,13 +1,28 @@
-"use client";
-
-import { useEffect } from "react";
-import { useSession, signIn } from "next-auth/react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const UnauthorizedPage = () => {
   return (
-    <div className="text-center p-6 text-red-600">
-      <h1 className="text-3xl font-bold">Access Denied</h1>
-      <p>You are not authorized to use this app.</p>
+    <div className="min-h-screen flex items-center justify-center p-6 bg-checkmate-secondary">
+      <Card className="max-w-md w-full">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">
+            Welcome to{" "}
+            <span className="text-checkmate-primary">CheckMate Checkers</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          <p className="text-muted-foreground">
+            To get started, head to the Telegram bot and type:
+          </p>
+          <p className="text-xl font-mono bg-muted px-4 py-2 rounded-md inline-block">
+            /onboard
+          </p>
+          <p className="text-sm text-muted-foreground">
+            This will guide you through the onboarding process to become a
+            checker.
+          </p>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -6,6 +6,11 @@ import { usePathname } from "next/navigation";
 const BottomNavigation = () => {
   const pathname = usePathname();
 
+  // Hide navigation on unauthorized page
+  if (pathname === "/unauthorized") {
+    return null;
+  }
+
   const navItems = [
     {
       path: "/dashboard",


### PR DESCRIPTION
## Summary
- Replace harsh "Access Denied" error with welcoming onboarding message
- Guide users to type `/onboard` in Telegram bot to get started
- Hide bottom navigation on unauthorized page since users can't access those routes anyway

Closes #51

## Test plan
- [ ] Visit `/unauthorized` directly and verify the new friendly message appears
- [ ] Verify bottom navigation is hidden on the unauthorized page
- [ ] Verify other pages still show bottom navigation normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)