### PR TITLE
fix: redirect to unauthorized immediately on auth failure

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,17 +54,8 @@ export default function HomePage() {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
-          <p className="text-red-500 mb-4">Authentication failed: {error}</p>
-          <button
-            onClick={() => {
-              // Reset the redirect flag and reload
-              hasRedirected.current = false;
-              window.location.reload();
-            }}
-            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-          >
-            Retry
-          </button>
+          <Loader2 className="animate-spin mx-auto mb-4" size={32} />
+          <p>Redirecting...</p>
         </div>
       </div>
     );

--- a/src/hooks/useTelegramAuth.ts
+++ b/src/hooks/useTelegramAuth.ts
@@ -118,8 +118,8 @@ export function useTelegramAuth() {
         setError(err instanceof Error ? err.message : "Authentication failed");
         setIsLoading(false);
 
-        // Redirect to unauthorized page after 3 seconds
-        setTimeout(() => router.push("/unauthorized"), 3000);
+        // Redirect to unauthorized page immediately
+        router.push("/unauthorized");
       }
     };
 


### PR DESCRIPTION
- Remove 3-second delay before redirecting to unauthorized page
- Show loading spinner instead of error message during redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)