### PR TITLE
Only authenticate users who have completed onboarding

### DIFF
--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -133,6 +133,11 @@ export const authConfig: NextAuthConfig = {
             return null;
           }
 
+          if (!user.isOnboardingComplete) {
+            console.warn("[Auth Config] User has not completed onboarding:", telegramId);
+            return null;
+          }
+
           console.log("[Auth Config] Authorization successful, returning user data");
           return {
             id: user._id?.toString() || "",


### PR DESCRIPTION
## Summary
- Add check for `isOnboardingComplete` in auth config
- Users who have started but not completed onboarding will now be redirected to the unauthorized page
- Prevents mid-onboarding users from accessing the webapp

## Test plan
- [ ] Start onboarding (`/onboard`) but don't complete it
- [ ] Try to access the webapp - should see the friendly unauthorized/onboarding page
- [ ] Complete onboarding and verify webapp access works

🤖 Generated with [Claude Code](https://claude.com/claude-code)