### PR TITLE
Fix viewpoints of Vote page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,7 @@
     min-height: 100dvh;
     min-height: -webkit-fill-available; /* legacy iOS */
     -webkit-tap-highlight-color: transparent;
+    overflow-x: hidden;
   }
 
   *,
@@ -108,6 +109,8 @@
     @apply bg-background text-foreground;
     min-height: inherit;
     overflow-x: hidden;
+    width: 100%;
+    max-width: 100vw;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({ children }: LayoutProps) {
         <SessionProviders>
           <UserProvider>
             <UseQueryProvider>
-              <div className="min-h-screen flex flex-col">
+              <div className="min-h-screen flex flex-col w-full max-w-full overflow-x-hidden">
                 {/* Add Nav bar at the top*/}
                 <div>
                   <TopHeaderShell />

--- a/src/components/voteContent/CommunityNoteCard.tsx
+++ b/src/components/voteContent/CommunityNoteCard.tsx
@@ -64,7 +64,7 @@ export default function CommunityNoteCard(props: CommunityNoteCardProps) {
   const textParts = splitTextByUrls(textToShow);
 
   return (
-    <Card className="bg-blue-100 p-3 mx-3 my-3">
+    <Card className="bg-blue-100 p-3 my-3 w-full overflow-hidden">
       <CardContent className="-m-2">
         <div className="flex items-center my-3">
           <UserIcon className="h-6 w-6 text-[#ff8932] mr-2 flex-shrink-0" />
@@ -85,7 +85,7 @@ export default function CommunityNoteCard(props: CommunityNoteCardProps) {
                         href={line}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-blue-500 hover:underline"
+                        className="text-blue-500 hover:underline break-all"
                       >
                         {line}
                       </a>

--- a/src/components/voteContent/MessageCard.tsx
+++ b/src/components/voteContent/MessageCard.tsx
@@ -78,7 +78,7 @@ export default function MessageCard(props: MessageCardProps) {
   const textParts = splitTextByUrls(textToShow);
 
   return (
-    <Card className="bg-orange-200 p-3 mx-3 my-2 border-orange-200">
+    <Card className="bg-orange-200 p-3 my-2 border-orange-200 w-full overflow-hidden">
       <CardContent className="-m-2">
         <div className="flex items-center my-3">
           <ChatBubbleLeftEllipsisIcon className="h-6 w-6 text-[#ff327d] mr-2 flex-shrink-0" />
@@ -100,7 +100,7 @@ export default function MessageCard(props: MessageCardProps) {
                         href={line}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-blue-500 hover:underline"
+                        className="text-blue-500 hover:underline break-all"
                       >
                         {line}
                       </a>

--- a/src/components/voteContent/VoteCategories.tsx
+++ b/src/components/voteContent/VoteCategories.tsx
@@ -142,7 +142,7 @@ export default function VoteCategories(props: VotingCategoriesProps) {
         <div key={index} className="w-full">
           <Button
             variant={selectedCategory === cat.name ? "voteCategories" : "default"}
-            className="flex flex-row items-center justify-start gap-2 max-w-md space-x-3 text-sm w-full"
+            className="flex flex-row items-center justify-start gap-2 space-x-3 text-sm w-full"
             key={index}
             onClick={() => handleSelection(cat.name)}
           >

--- a/src/components/voteContent/VoteContent.tsx
+++ b/src/components/voteContent/VoteContent.tsx
@@ -39,7 +39,7 @@ export const VoteContent = ({ voteId,
 
   return (
       <>
-      <div className="grid grid-flow-row items-center gap-2 p-3">
+      <div className="grid grid-flow-row items-center gap-2 p-3 w-full max-w-full overflow-hidden">
         <MessageCard text={poll.text} caption={poll.caption} imageUrl={poll.imageURL} />
 
         {poll.shortformResponse.en && !showNoteAfterVote? (


### PR DESCRIPTION
  ---
  Summary

  - Fix horizontal overflow causing unwanted horizontal scrolling on /votes/[id] page in Telegram webapp
  - Add proper width constraints and overflow handling throughout the layout chain
  - Ensure long URLs wrap properly instead of breaking the layout

  Changes

  Global styles (globals.css):
  - Added overflow-x: hidden to html element
  - Added width: 100% and max-width: 100vw to body

  Layout (layout.tsx):
  - Added w-full max-w-full overflow-x-hidden to main container

  Vote page components:
  - VoteContent.tsx: Added w-full max-w-full overflow-hidden to grid container
  - MessageCard.tsx: Removed mx-3 margin, added w-full overflow-hidden, added break-all to URL links
  - CommunityNoteCard.tsx: Removed mx-3 margin, added w-full overflow-hidden, added break-all to URL links
  - VoteCategories.tsx: Removed fixed max-w-md width constraint on category buttons

  Root causes

  1. Long URLs without word-breaking were overflowing their containers
  2. mx-3 margins on Cards combined with parent padding caused elements to exceed viewport width
  3. Fixed max-w-md width on buttons didn't adapt to smaller Telegram webapp viewports

  Test plan

  - Open /votes/[id] page in Telegram webapp on various device sizes
  - Verify no horizontal scrollbar appears
  - Test with messages containing long URLs to ensure they wrap correctly
  - Verify vote category buttons display properly on narrow screens

Closes #58 