### PR TITLE
Ensure that the render status dot shows the corret status

### DIFF
--- a/src/components/voteDashboard/InfiniteVoteMessageList.tsx
+++ b/src/components/voteDashboard/InfiniteVoteMessageList.tsx
@@ -28,7 +28,7 @@ export const InfiniteVoteMessageList = (props: InfiniteVoteMessageProps) => {
 
   const results = data?.pages.flatMap((page: any) => page.data.items ?? []) ?? [];
 
-  // console.log(results);
+  console.log(results);
 
   const handleLoadData = useCallback(() => {
     // Check if there's more data to load
@@ -55,6 +55,7 @@ export const InfiniteVoteMessageList = (props: InfiniteVoteMessageProps) => {
             truthScore={result.truthScore}
             responseCategory={result.responseCategory}
             commentOnResponse={result.commentOnResponse}
+            isCorrect={result.isCorrect}
           />
         );
       })}

--- a/src/components/voteDashboard/voteMessageCard.tsx
+++ b/src/components/voteDashboard/voteMessageCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { PencilIcon } from "lucide-react";
-import Link from "next/link";
+import { PencilIcon } from 'lucide-react';
+import Link from 'next/link';
 
-import { IconQuestionMark } from "@tabler/icons-react";
+import { IconQuestionMark } from '@tabler/icons-react';
 
 interface VoteMessageCardProps {
   voteId: string; // Vote ID
@@ -36,6 +36,7 @@ interface VoteMessageCardProps {
   truthScore: 0 | 1 | 2 | 3 | 4 | 5 | null;
   responseCategory: "great" | "acceptable" | "unacceptable" | null;
   commentOnResponse: string | null;
+  isCorrect: boolean | null;
 }
 
 type ColourMap = {
@@ -89,7 +90,7 @@ export const VoteMessageCard = (props: VoteMessageCardProps) => {
   const dateString = dateToDateString(new Date(props.startedTimestamp));
   function renderStatusDot() {
     // Checking if the status is 'voted'
-    if (props.category !== null && props.crowdSourcedCategory !== null) {
+    if (props.category !== null && props.crowdSourcedCategory !== null && props.isCorrect !== null) {
       // If Checker already vote
       if (props.crowdSourcedCategory === "unsure") {
         return (
@@ -100,7 +101,7 @@ export const VoteMessageCard = (props: VoteMessageCardProps) => {
         );
       } else {
         // Check if users is correct/wrong
-        if (props.category === props.crowdSourcedCategory && props.crowdSourcedCategory !== null) {
+        if (props.isCorrect) {
           // Checker is correct
           return (
             <div className="flex-shrink-0 w-12 flex items-center justify-center">

--- a/workers/checkers-db-service/src/index.ts
+++ b/workers/checkers-db-service/src/index.ts
@@ -216,6 +216,7 @@ export class DatabaseDurableObject extends DurableObject<Env> {
             truthScore: 1,
             responseCategory: 1,
             commentOnResponse: 1,
+            isCorrect: 1,
             poll: {
               _id: { $toString: "$poll._id" },
               checkId: {


### PR DESCRIPTION
  Summary

  - Fixed bug where the vote message card status dot was showing red (incorrect) even when the checker's vote was correct
  - The issue was caused by comparing the checker's category directly with the crowd-sourced category instead of using the pre-calculated isCorrect field

  Test plan

  - Submit a vote on a poll that has reached consensus
  - Navigate to the dashboard and verify the status dot shows:
    - Green checkmark when isCorrect is true
    - Red X when isCorrect is false
    - Question mark when crowd-sourced category is "unsure"
    - Pending indicator when poll hasn't reached consensus yet

  Changes

  - src/components/voteDashboard/voteMessageCard.tsx - Use isCorrect prop instead of comparing categories directly
  - src/components/voteDashboard/InfiniteVoteMessageList.tsx - Pass isCorrect prop to VoteMessageCard
  - workers/checkers-db-service/src/index.ts - Include isCorrect field in the votes query projection

Closes #57 

  🤖 Generated with https://claude.com/claude-code