### PR TITLE
feat: A/B test for community note display order

### DIFF
--- a/shared/types/schema.ts
+++ b/shared/types/schema.ts
@@ -108,6 +108,7 @@ export interface Vote extends BaseDocument {
   responseTime: number | null; // Time taken to submit the vote in hours
   score: number | null; // Score awarded for this vote
   isCorrect: boolean | null; // Whether the vote matched the consensus
+  showNoteAfterVote: boolean; // A/B test flag: true = show community note after voting, false = show before
 }
 
 // OTHER TYPES

--- a/src/app/votes/[voteId]/page.tsx
+++ b/src/app/votes/[voteId]/page.tsx
@@ -1,13 +1,11 @@
-import { auth } from '@/auth';
-import { VoteContent } from '@/components/voteContent/VoteContent';
+import { auth } from "@/auth";
+import { VoteContent } from "@/components/voteContent/VoteContent";
 
 export default async function VotePage({ params }: { params: Promise<{ voteId: string }> }) {
   const { voteId } = await params;
 
   const session = await auth();
   if (!session?.user) return null;
-  
-  return <VoteContent 
-            voteId={voteId} 
-            showNoteAfterVote={false}/>;
+
+  return <VoteContent voteId={voteId} />;
 }

--- a/src/components/voteContent/ReferenceLinksCard.tsx
+++ b/src/components/voteContent/ReferenceLinksCard.tsx
@@ -1,0 +1,37 @@
+import { LinkIcon } from "@heroicons/react/20/solid";
+
+import { Card, CardContent } from "../ui/card";
+
+interface ReferenceLinksCardProps {
+  links: string[] | null;
+}
+
+export default function ReferenceLinksCard({ links }: ReferenceLinksCardProps) {
+  if (!links || links.length === 0) return null;
+
+  return (
+    <Card className="bg-slate-100 p-3 mx-3 my-3">
+      <CardContent className="-m-2">
+        <div className="flex items-center my-3">
+          <LinkIcon className="h-6 w-6 text-slate-600 mr-2 flex-shrink-0" />
+          <p className="font-semibold text-slate-700 leading-none">Reference Links:</p>
+        </div>
+        <ul className="list-disc pt-1">
+          {links.map(link => (
+            <li className="flex gap-x-2" key={link}>
+              <LinkIcon aria-hidden="true" className="h-6 w-5 flex-none text-slate-400" />
+              <a
+                href={link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline break-all"
+              >
+                {link}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/voteContent/VoteContent.tsx
+++ b/src/components/voteContent/VoteContent.tsx
@@ -7,15 +7,14 @@ import { useGetVotesById } from '@/hooks/votes/useGetVotesById';
 
 import CommunityNoteCard from './CommunityNoteCard';
 import MessageCard from './MessageCard';
+import ReferenceLinksCard from './ReferenceLinksCard';
 import VoteResultsDisplay from './VoteResultsDisplay';
 import VotingSystem from './VotingSystem';
 
 interface VoteContentProps {
   voteId: string;
-  showNoteAfterVote: boolean;
 }
-export const VoteContent = ({ voteId, 
-                              showNoteAfterVote } : VoteContentProps) => {
+export const VoteContent = ({ voteId }: VoteContentProps) => {
   const { data: vote, isLoading: isLoading_Vote, error: isError_Vote } = useGetVotesById(voteId);
 
   // Fetch the poll using pollId (which is the poll's _id)
@@ -37,12 +36,19 @@ export const VoteContent = ({ voteId,
   // handle error states
   if (isError_Poll) return <div>Failed to load poll</div>;
 
+  // A/B test flag from vote data (fallback to false for existing votes without the field)
+  const showNoteAfterVote = vote.showNoteAfterVote ?? false;
+
   return (
       <>
       <div className="grid grid-flow-row items-center gap-2 p-3">
         <MessageCard text={poll.text} caption={poll.caption} imageUrl={poll.imageURL} />
 
-        {poll.shortformResponse.en && !showNoteAfterVote? (
+        {showNoteAfterVote && poll.shortformResponse.links && (
+          <ReferenceLinksCard links={poll.shortformResponse.links} />
+        )}
+
+        {poll.shortformResponse.en && !showNoteAfterVote ? (
           <CommunityNoteCard
             responseEN={poll.shortformResponse.en}
             responseCN={poll.shortformResponse.cn}

--- a/src/lib/request/external/lib/data-contracts.ts
+++ b/src/lib/request/external/lib/data-contracts.ts
@@ -219,6 +219,8 @@ export type Vote = BaseDocument & {
   /** Evaluation for an AI response quality (nullable) */
   responseCategory?: ResponseCategory;
   commentOnResponse?: string | null;
+  /** A/B test flag: true = show community note after voting, false = show before */
+  showNoteAfterVote?: boolean;
 };
 
 /** POST reqeust body to update the Vote Content of user  */

--- a/workers/checkers-webhook-service/src/polls.ts
+++ b/workers/checkers-webhook-service/src/polls.ts
@@ -141,9 +141,10 @@ export async function handlePollWebhook(c: Context<{ Bindings: Env }>) {
         truthScore: null,
         responseCategory: null,
         commentOnResponse: null,
-        responseTime: null, 
-        score: null, 
-        isCorrect: null
+        responseTime: null,
+        score: null,
+        isCorrect: null,
+        showNoteAfterVote: Math.random() < 0.5, // A/B test: 50/50 split
       };
 
       const insertVoteResult = await env.CHECKERS_DB_SERVICE.insertVote(voteRequest);

--- a/workers/checkers-webhook-service/src/types.ts
+++ b/workers/checkers-webhook-service/src/types.ts
@@ -134,6 +134,7 @@ export interface VoteAPI {
   responseTime: number | null; // Time taken to submit the vote in hours
   score: number | null; // Score awarded for this vote
   isCorrect: boolean | null; // Whether the vote matched the consensus
+  showNoteAfterVote: boolean; // A/B test flag: true = show community note after voting, false = show before
 }
 
 // Poll request from CheckMate AI platform


### PR DESCRIPTION
## Summary
- Add `showNoteAfterVote` field to Vote schema with 50/50 random assignment at vote creation
- When `showNoteAfterVote=true`: hide community note until after voting, but show reference links upfront
- When `showNoteAfterVote=false`: show community note immediately (existing behavior)
- Existing votes without the field default to `false` for backwards compatibility

## Test plan
- [ ] Create a new poll via webhook and verify votes are assigned random `showNoteAfterVote` values
- [ ] Test voting flow with `showNoteAfterVote=true`: reference links visible, community note hidden until step 1 complete
- [ ] Test voting flow with `showNoteAfterVote=false`: community note visible immediately
- [ ] Verify existing votes still work (fallback to false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)