### PR TITLE
fix: update lastVotedTimestamp when vote is submitted

### DIFF
--- a/workers/checkers-event-handler-service/src/handlers/queue/onVoteSubmitted.ts
+++ b/workers/checkers-event-handler-service/src/handlers/queue/onVoteSubmitted.ts
@@ -32,6 +32,12 @@ export async function handleVoteSubmitted(
   const vote = voteResult.data;
   const pollId = vote.pollId;
 
+  // Update checker's lastVotedTimestamp for inactivity tracking
+  await env.CHECKERS_DB_SERVICE.updateOneChecker(
+    { _id: vote.checkerId },
+    { $set: { lastVotedTimestamp: new Date() } }
+  );
+
   // Update Telegram button text to indicate vote was submitted
   await updateVoteButtonText(env, vote);
 


### PR DESCRIPTION
## Summary

- Fixes bug where `lastVotedTimestamp` was never updated when checkers submitted votes
- This caused the inactivity detection logic to incorrectly flag active checkers as inactive
- Adds update to checker's `lastVotedTimestamp` in the `vote.submitted` event handler

## Problem

The inactivity logic in `getLastActiveDate()` uses the most recent of:
- `lastVotedTimestamp`
- `onboardingTime`
- `lastActivatedDate`

However, `lastVotedTimestamp` was never being set, so checkers who voted regularly could still be flagged as inactive after 10 days from their onboarding or last reactivation.

## Test plan

- [ ] Submit a vote as a checker
- [ ] Verify `lastVotedTimestamp` is updated in the database
- [ ] Verify inactivity checks don't flag active voters

## Related

- #74 tracks the separate issue of computing `numVoted` dynamically for the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)