### PR TITLE
fix: correct parseInt radix bug in accuracy nudge check

### DIFF
--- a/workers/checkers-event-handler-service/src/handlers/queue/onVoteScoreChange.ts
+++ b/workers/checkers-event-handler-service/src/handlers/queue/onVoteScoreChange.ts
@@ -76,8 +76,8 @@ async function checkAccuracyNudge(
   programme: { _id: string; hasReceivedLowAccuracyWarning: boolean },
   progress: { voteCount: number; accuracy: number | null }
 ): Promise<void> {
-  const voteThreshold = parseInt(env.ACCURACY_NUDGE_VOTE_THRESHOLD, 20);
-  const accuracyThreshold = parseInt(env.ACCURACY_NUDGE_THRESHOLD, 50);
+  const voteThreshold = parseInt(env.ACCURACY_NUDGE_VOTE_THRESHOLD) || 20;
+  const accuracyThreshold = parseInt(env.ACCURACY_NUDGE_THRESHOLD) || 50;
 
   // Already received warning - skip
   if (programme.hasReceivedLowAccuracyWarning) {


### PR DESCRIPTION
## Summary
- Fixed `parseInt` calls that incorrectly used intended default values as the radix parameter
- `parseInt(env.ACCURACY_NUDGE_THRESHOLD, 50)` returned `NaN` since radix must be 2-36
- This caused `accuracy >= NaN` to always be `false`, sending warnings to all checkers regardless of actual accuracy

## Test plan
- [ ] Deploy to staging and verify accuracy nudge only triggers for checkers with accuracy below threshold
- [ ] Confirm checkers with good accuracy no longer receive false warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)