### PR TITLE
feat: keep category section open after selection and scroll to next

### DIFF
--- a/src/components/voteContent/VotingSystem.tsx
+++ b/src/components/voteContent/VotingSystem.tsx
@@ -26,7 +26,7 @@ interface IconProps {
 
 export default function VotingSystem(props: VotingSystemProps) {
   // local state mirrors the original behaviour
-  const [openItems, setOpenItems] = useState<string>("1");
+  const [openItems, setOpenItems] = useState<string[]>(["1"]);
   const [voteCategory, setVoteCategory] = useState<Category | null>(props.category);
   const [truthScore, setTruthScore] = useState<number | null>(props.truthScore);
   const [crowdSourcedCategory, setCrowdSourcedCategory] = useState<ResponseCategory | null>(
@@ -46,13 +46,19 @@ export default function VotingSystem(props: VotingSystemProps) {
     return true;
   };
 
-  const handleNextStep = (value: number) => {
-    // Enable the next accordion and open it automatically
-    setOpenItems(String(value));
-  };
-
   const onNextStep = (value: number) => {
-    handleNextStep(value);
+    const stepStr = String(value);
+    if (props.showNoteAfterVote) {
+      // A/B test mode: collapse previous sections, only show current
+      setOpenItems([stepStr]);
+    } else {
+      // Default: keep section 1 open and also open section 2, then scroll
+      setOpenItems(prev => (prev.includes(stepStr) ? prev : [...prev, stepStr]));
+      // Scroll to the next section after a short delay for accordion to expand
+      setTimeout(() => {
+        document.getElementById(`step-${value}`)?.scrollIntoView({ behavior: "smooth" });
+      }, 100);
+    }
   };
 
   const handleVoteCategorySelection = (value: Category) => {
@@ -82,7 +88,7 @@ export default function VotingSystem(props: VotingSystemProps) {
 
   return (
     <div>
-      <Accordion type="single" collapsible value={openItems} onValueChange={setOpenItems}>
+      <Accordion type="multiple" value={openItems} onValueChange={setOpenItems}>
         <AccordionItem
           value="1"
           className={`mb-6 mx-2 rounded-lg border px-2 relative ${
@@ -128,6 +134,7 @@ export default function VotingSystem(props: VotingSystemProps) {
         ) : null}
         {hasCommunityNote ? (
           <AccordionItem
+            id="step-2"
             value="2"
             className={`mb-2 mt-6 mx-2 rounded-lg border px-2 relative ${openItems.includes("2") ? "ring-2 ring-amber-400 ring-offset-2 ring-offset-slate-50" : "border-blue-gray-200"}`}
           >


### PR DESCRIPTION
## Summary
- When `showNoteAfterVote=false`, the category section now stays open after selection
- Users can verify their choice before moving on
- Viewport scrolls to the community note rating section which also expands
- Changed accordion from single to multiple mode to support both sections open

## Test plan
- [ ] Select a category and verify section 1 stays open
- [ ] Verify viewport scrolls to section 2
- [ ] Verify section 2 is expanded
- [ ] Test with `showNoteAfterVote=true` to confirm A/B test mode still collapses section 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)