### PR TITLE
fix: calculate 30-day stats by querying votes directly

### DIFF
--- a/src/app/api/checkers/[checkerId]/stats/route.ts
+++ b/src/app/api/checkers/[checkerId]/stats/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { auth } from "@/auth";
 import { Err } from "@/lib/api/error";
-import { calculateProgrammeProgress } from "@/lib/helpers/programmeProgress";
+import { getReportCount } from "@/lib/helpers/getReportCount";
+import { computeAccuracyPercentage } from "@/shared/helpers/scoring";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 export async function GET(req: NextRequest, { params }) {
@@ -16,24 +17,37 @@ export async function GET(req: NextRequest, { params }) {
 
     if (!checkerId) return Err.badParams("Missing checkerId parameter");
 
-    const today = new Date();
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(today.getDate() - 30);
-
-    const votesStats = await calculateProgrammeProgress(env, checkerId, {
-      startDate: thirtyDaysAgo,
-      votesAtStart: 0,
-    });
-
-    if (!votesStats.success || !votesStats.data) {
+    // Get checker for whatsappId
+    const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({ _id: checkerId });
+    if (!checkerResult.success || !checkerResult.data) {
       return Err.notFound();
     }
 
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+    // Query votes from the last 30 days
+    const votesResult = await env.CHECKERS_DB_SERVICE.findVotes({
+      checkerId,
+      votedTimestamp: { $gte: thirtyDaysAgo },
+    });
+
+    if (!votesResult.success) {
+      return Err.internal();
+    }
+
+    const votes = votesResult.data ?? [];
+    const voteCount = votes.length;
+    const accuracy = computeAccuracyPercentage(votes);
+
+    // Get report count from the last 30 days
+    const reportCount = await getReportCount(env, checkerResult.data.whatsappId, thirtyDaysAgo);
+
     return NextResponse.json(
       {
-        voteCount: votesStats.data.voteCount,
-        accuracy: votesStats.data.accuracy,
-        reports: votesStats.data.reportCount,
+        voteCount,
+        accuracy,
+        reports: reportCount.count,
       },
       { status: 200 }
     );


### PR DESCRIPTION
## Summary

- Fixed the stats endpoint for non-programme checkers showing incorrect vote count
- Was showing lifetime `numVoted` instead of votes from the last 30 days
- Root cause: misusing `calculateProgrammeProgress` with `votesAtStart=0`, resulting in `checker.numVoted - 0 = total lifetime votes`

## Changes

- Now queries votes directly with `votedTimestamp >= thirtyDaysAgo`
- Counts actual vote results for the 30-day period
- Accuracy and report count also correctly filtered by date

## Test plan

- [x] All unit tests pass (118 tests)
- [ ] Verify dashboard shows correct 30-day stats for non-programme checkers

🤖 Generated with [Claude Code](https://claude.com/claude-code)