### PR TITLE
fix: improve leaderboard display and calculations

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -11,10 +11,20 @@ export async function GET(req: NextRequest) {
     const session = await auth();
     if (!session?.user) return Err.unauthorized();
 
-    // Calculate current month's date range dynamically
+    // Calculate current month's date range in SGT (UTC+8)
+    // Cloudflare Workers run in UTC, so we need to offset to SGT
+    const SGT_OFFSET_MS = 8 * 60 * 60 * 1000;
     const now = new Date();
-    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-    const startOfNextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+    const nowSGT = new Date(now.getTime() + SGT_OFFSET_MS);
+
+    // Get year/month as it would be in SGT
+    const year = nowSGT.getUTCFullYear();
+    const month = nowSGT.getUTCMonth();
+
+    // Create UTC timestamps that represent midnight SGT
+    // e.g., Jan 1 2026 00:00 SGT = Dec 31 2025 16:00 UTC
+    const startOfMonth = new Date(Date.UTC(year, month, 1) - SGT_OFFSET_MS);
+    const startOfNextMonth = new Date(Date.UTC(year, month + 1, 1) - SGT_OFFSET_MS);
 
     const result = await env.CHECKERS_DB_SERVICE.getLeaderboardInfo(startOfMonth, startOfNextMonth);
 

--- a/src/components/leaderboard/leaderboard-table.tsx
+++ b/src/components/leaderboard/leaderboard-table.tsx
@@ -19,7 +19,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/
 import { LeaderboardRows } from "./leaderboard-rows";
 
 // Number of top positions to always show
-const TOP_N = 10;
+const TOP_N = 5;
+// Number of positions above/below current user to show
+const CONTEXT_SIZE = 2;
 
 interface LeaderboardTableProps {
   currentUserId: string;
@@ -77,18 +79,20 @@ export function LeaderboardTable({ currentUserId }: LeaderboardTableProps) {
       }));
 
     // Find current user's position
-    const currentUserIndex = sorted.findIndex(entry => entry.id === currentUserId);
+    const currentUserIndex = sorted.findIndex(entry => entry._id === currentUserId);
 
     // If user is in top N or not found, just show top N
     if (currentUserIndex === -1 || currentUserIndex < TOP_N) {
       return { abridgedLeaderboard: sorted.slice(0, TOP_N) };
     }
 
-    // Otherwise, show top N + current user ( and optionally neighbours)
+    // Otherwise, show top N + current user with context (±CONTEXT_SIZE)
     const topN = sorted.slice(0, TOP_N);
 
-    // Include one position above and below current user for context
-    const userSection = sorted.slice(Math.max(TOP_N, currentUserIndex - 1), currentUserIndex + 2);
+    // Include positions above and below current user for context
+    const userSectionStart = Math.max(TOP_N, currentUserIndex - CONTEXT_SIZE);
+    const userSectionEnd = Math.min(sorted.length, currentUserIndex + CONTEXT_SIZE + 1);
+    const userSection = sorted.slice(userSectionStart, userSectionEnd);
 
     return { abridgedLeaderboard: [...topN, ...userSection] };
   }, [leaderboardList?.data, currentUserId]);

--- a/workers/checkers-db-service/src/index.ts
+++ b/workers/checkers-db-service/src/index.ts
@@ -595,12 +595,13 @@ export class DatabaseDurableObject extends DurableObject<Env> {
 
       const aggregationPipeline = [
         {
-          // Step 1: Filter by currrent month
+          // Step 1: Filter by votes created in the current month (and actually voted on)
           $match: {
-            votedTimestamp: {
+            createdTimestamp: {
               $gte: startOfMonth,
               $lt: startOfNextMonth,
             },
+            votedTimestamp: { $ne: null }, // Only count submitted votes
           },
         },
         {


### PR DESCRIPTION
## Summary

- **SGT timezone**: Leaderboard now uses Singapore timezone for month boundaries instead of UTC
- **Filter by createdTimestamp**: Votes are counted based on when they were assigned, not when voted
- **Display fix**: Show top 5 + ±2 around current user (was showing only top 10)
- **Bug fix**: Fixed user lookup using `_id` instead of `id` - users were never being found before

## Changes

| File | Change |
|------|--------|
| `src/app/api/leaderboard/route.ts` | SGT timezone offset for month calculations |
| `workers/checkers-db-service/src/index.ts` | Filter by `createdTimestamp` instead of `votedTimestamp` |
| `src/components/leaderboard/leaderboard-table.tsx` | TOP_N=5, CONTEXT_SIZE=2, fix `_id` lookup |

## Test plan

- [x] All unit tests pass (118 tests)
- [ ] Verify leaderboard shows top 5 + user's position with context
- [ ] Verify current user's row is highlighted in orange
- [ ] Verify month boundaries align with SGT

🤖 Generated with [Claude Code](https://claude.com/claude-code)