### PR TITLE
Update checker-stats endpoint to batch API

### DIFF
--- a/workers/checkers-webhook-service/src/checker-stats.ts
+++ b/workers/checkers-webhook-service/src/checker-stats.ts
@@ -2,83 +2,104 @@ import { Context } from "hono";
 
 import type { ProgrammeAPI } from "./types";
 
+interface CheckerStatsResponse {
+  whatsappId: string;
+  onboardingStatus: string;
+  onboardingTime: Date | null;
+  hasCompletedProgram: boolean;
+  programEndTimestamp: Date | null;
+  certificateUrl: string | null;
+  offboardingTime: Date | null;
+}
+
 export async function handleCheckerStatsWebhook(c: Context<{ Bindings: Env }>) {
   const env = c.env;
 
-  // Verify API key
   const apiKey = c.req.header("x-api-key");
   if (!apiKey || apiKey !== env.API_KEY) {
     return c.json({ error: "Unauthorized" }, 401);
   }
 
   try {
-    // Get whatsappId from query parameter
-    const whatsappId = c.req.query("whatsappId");
-    if (!whatsappId) {
-      return c.json({ error: "Missing 'whatsappId' query parameter" }, 400);
+    const body = await c.req.json<{ whatsappIds: string[] }>();
+
+    if (!body.whatsappIds || !Array.isArray(body.whatsappIds)) {
+      return c.json({ error: "Missing 'whatsappIds' array in request body" }, 400);
     }
 
-    // Find checker by whatsappId
-    const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({
-      whatsappId: whatsappId,
-    });
-
-    if (!checkerResult.success) {
-      console.error("[CHECKER-STATS ERROR]", checkerResult.error);
-      return c.json({ error: checkerResult.error || "Failed to find checker" }, 500);
+    if (body.whatsappIds.length > 100) {
+      return c.json({ error: "Maximum 100 whatsappIds per request" }, 400);
     }
 
-    if (!checkerResult.data) {
-      return c.json({ error: "Checker not found" }, 404);
-    }
-
-    const checker = checkerResult.data;
-
-    // Find all programmes for this checker
-    const programmesResult = await env.CHECKERS_DB_SERVICE.findProgrammes({
-      checkerId: checker._id,
-    });
-
-    if (!programmesResult.success) {
-      console.error("[CHECKER-STATS ERROR]", programmesResult.error);
-      return c.json({ error: programmesResult.error || "Failed to find programmes" }, 500);
-    }
-
-    const programmes = programmesResult.data || [];
-
-    // Find the earliest completedAt from all programmes
-    let programEndTimestamp: Date | null = null;
-    let hasCompletedProgram = false;
-    let certificateUrl: string | null = null;
-
-    // Filter programmes with completedAt and find the earliest one
-    const completedProgrammes = programmes.filter(
-      (p: ProgrammeAPI) => p.completedAt !== null && p.status === "completed"
+    // Fetch all checkers in parallel
+    const results = await Promise.all(
+      body.whatsappIds.map(async whatsappId => {
+        const stats = await getCheckerStats(env, whatsappId);
+        return { whatsappId, stats };
+      })
     );
 
-    if (completedProgrammes.length > 0) {
-      hasCompletedProgram = true;
-      // Sort by completedAt ascending to get the earliest
-      completedProgrammes.sort((a: ProgrammeAPI, b: ProgrammeAPI) => {
-        const dateA = new Date(a.completedAt!).getTime();
-        const dateB = new Date(b.completedAt!).getTime();
-        return dateA - dateB;
-      });
-      programEndTimestamp = completedProgrammes[0].completedAt;
-      certificateUrl = completedProgrammes[0].certificateUrl;
+    // Return as object keyed by whatsappId for easy lookup
+    const resultsMap: Record<string, CheckerStatsResponse | null> = {};
+    for (const { whatsappId, stats } of results) {
+      resultsMap[whatsappId] = stats;
     }
 
-    return c.json({
-      whatsappId: checker.whatsappId,
-      onboardingStatus: checker.onboardingStatus,
-      onboardingTime: checker.onboardingTime,
-      hasCompletedProgram: hasCompletedProgram,
-      programEndTimestamp: programEndTimestamp,
-      certificateUrl: certificateUrl,
-      offboardingTime: checker.offboardingTime,
-    });
+    return c.json({ results: resultsMap });
   } catch (err) {
     console.error("[CHECKER-STATS ERROR]", err);
     return c.json({ error: "Server error" }, 500);
   }
+}
+
+async function getCheckerStats(env: Env, whatsappId: string): Promise<CheckerStatsResponse | null> {
+  const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({
+    whatsappId: whatsappId,
+  });
+
+  if (!checkerResult.success || !checkerResult.data) {
+    return null;
+  }
+
+  const checker = checkerResult.data;
+
+  const programmesResult = await env.CHECKERS_DB_SERVICE.findProgrammes({
+    checkerId: checker._id,
+  });
+
+  if (!programmesResult.success) {
+    console.error("[CHECKER-STATS ERROR]", programmesResult.error);
+    return null;
+  }
+
+  const programmes = programmesResult.data || [];
+
+  let programEndTimestamp: Date | null = null;
+  let hasCompletedProgram = false;
+  let certificateUrl: string | null = null;
+
+  const completedProgrammes = programmes.filter(
+    (p: ProgrammeAPI) => p.completedAt !== null && p.status === "completed"
+  );
+
+  if (completedProgrammes.length > 0) {
+    hasCompletedProgram = true;
+    completedProgrammes.sort((a: ProgrammeAPI, b: ProgrammeAPI) => {
+      const dateA = new Date(a.completedAt!).getTime();
+      const dateB = new Date(b.completedAt!).getTime();
+      return dateA - dateB;
+    });
+    programEndTimestamp = completedProgrammes[0].completedAt;
+    certificateUrl = completedProgrammes[0].certificateUrl;
+  }
+
+  return {
+    whatsappId: checker.whatsappId,
+    onboardingStatus: checker.onboardingStatus,
+    onboardingTime: checker.onboardingTime,
+    hasCompletedProgram,
+    programEndTimestamp,
+    certificateUrl,
+    offboardingTime: checker.offboardingTime,
+  };
 }

--- a/workers/checkers-webhook-service/src/index.ts
+++ b/workers/checkers-webhook-service/src/index.ts
@@ -37,7 +37,7 @@ app.post("/typeform", handleTypeformWebhook);
 // Poll webhook endpoint for receiving checks from CheckMate
 app.post("/polls/webhook", handlePollWebhook);
 
-// Checker stats endpoint for ops automation
-app.get("/checker-stats", handleCheckerStatsWebhook);
+// Checker stats endpoint for ops automation (batch)
+app.post("/checker-stats", handleCheckerStatsWebhook);
 
 export default app;


### PR DESCRIPTION
## Summary
- Replace single-checker GET endpoint with batch POST endpoint
- Accepts up to 100 whatsappIds in request body
- Returns stats for all checkers in parallel using `Promise.all`
- Enables efficient bulk lookups from Google Apps Script without BigQuery

## Test plan
- [ ] Deploy to staging
- [ ] Test with curl: `curl -X POST https://staging-url/checker-stats -H "x-api-key: KEY" -H "Content-Type: application/json" -d '{"whatsappIds": ["6512345678"]}'`
- [ ] Update Google Apps Script to use new batch endpoint
- [ ] Verify spreadsheet updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)