### PR TITLE
Fix deep link auth redirect

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useTelegramAuth } from "@/hooks/useTelegramAuth";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { Loader2 } from "lucide-react";
 
 export default function HomePage() {
   const { isLoading, error, session } = useTelegramAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const hasRedirected = useRef(false);
+
+  const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
 
   // Debug logging
   console.log(
@@ -19,25 +22,24 @@ export default function HomePage() {
     "session:",
     !!session,
     "hasRedirected:",
-    hasRedirected.current
+    hasRedirected.current,
+    "callbackUrl:",
+    callbackUrl
   );
 
   useEffect(() => {
     // Only redirect once when we have a session and haven't redirected yet
     if (!isLoading && !error && session && !hasRedirected.current) {
-      console.log("[HomePage] Redirecting to dashboard");
+      console.log("[HomePage] Redirecting to", callbackUrl);
       hasRedirected.current = true;
 
-      // Try multiple redirect methods to ensure it works
-      const redirect = () => {
-        console.log("[HomePage] Redirecting using window.location.replace");
-        window.location.replace("/dashboard");
-      };
-
       // Small delay to ensure everything is ready
-      setTimeout(redirect, 100);
+      setTimeout(() => {
+        console.log("[HomePage] Redirecting using window.location.replace");
+        window.location.replace(callbackUrl);
+      }, 100);
     }
-  }, [isLoading, error, session, router]);
+  }, [isLoading, error, session, router, callbackUrl]);
 
   if (isLoading) {
     return (
@@ -67,16 +69,16 @@ export default function HomePage() {
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <Loader2 className="animate-spin mx-auto mb-4" size={32} />
-          <p>Redirecting to dashboard...</p>
+          <p>Redirecting...</p>
           <p className="text-sm text-gray-500 mt-2">Session: {session.user?.name || "Unknown"}</p>
           <button
             onClick={() => {
               console.log("[HomePage] Manual redirect clicked");
-              window.location.href = "/dashboard";
+              window.location.href = callbackUrl;
             }}
             className="mt-4 px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
           >
-            Go to Dashboard Manually
+            Continue Manually
           </button>
         </div>
       </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,11 +49,12 @@ export async function middleware(request: NextRequest) {
       });
     }
 
-    // If no valid token, redirect
+    // If no valid token, redirect to home page for Telegram auth with callback
     if (!token) {
-      console.log(`[Middleware] No valid token, redirecting to unauthorized`);
+      console.log(`[Middleware] No valid token, redirecting to home for auth`);
 
-      const response = NextResponse.redirect(new URL("/unauthorized", request.url));
+      const callbackUrl = encodeURIComponent(pathname + request.nextUrl.search);
+      const response = NextResponse.redirect(new URL(`/?callbackUrl=${callbackUrl}`, request.url));
 
       // Clean up invalid cookies
       response.cookies.delete("__Secure-next-auth.session-token");


### PR DESCRIPTION
 ## Summary                                                                                                                                                       
                                                                                                                                                                
  - Unauthenticated users visiting deep links (e.g. /votes/123) are now redirected to the home page to authenticate via Telegram, then forwarded to their       
  original destination                                                                                                                                          
  - Previously, unauthenticated users on protected routes were sent to /unauthorized with no way back to their intended page                                    
                                                                                                                                                                
  ## Problem                                                                                                                                                       
                                                                                                                                                                
  When users opened a Telegram deep link to a specific page like /votes/123, the middleware detected no session cookie and redirected them straight to          
  /unauthorized. Since the Telegram auth flow (useTelegramAuth) only runs on the home page, there was no way for these users to authenticate without manually   
  navigating to /.                                                                                                                                              
                                                                                                                                                                
 ##  Changes                                                                                                                                                       
                                                                                                                                                                
  - src/middleware.ts: Redirect unauthenticated users to /?callbackUrl=<original-path> instead of /unauthorized                                                 
  - src/app/page.tsx: Read callbackUrl from search params and redirect there after successful auth (defaults to /dashboard if no callback)                      
                                                                                                                                                                
  ## How it works                                                                                                                                                  
                                                                                                                                                                
  1. User opens /votes/123 without a session cookie                                                                                                             
  2. Middleware redirects to /?callbackUrl=%2Fvotes%2F123                                                                                                       
  3. Home page runs the Telegram auth flow                                                                                                                      
  4. On success, redirects to /votes/123                                                                                                                        
  5. On failure, useTelegramAuth still redirects to /unauthorized as before                                                                                     
                                                                                                                                                                
  ## Test plan                                                                                                                                                     
                                                                                                                                                                
  - Open a deep link (e.g. /votes/<id>) in Telegram without an existing session — should authenticate and land on the vote page                                 
  - Open the app normally (no deep link) — should authenticate and land on /dashboard as before                                                                 
  - Open a deep link when authentication fails (e.g. user not onboarded) — should end up on /unauthorized                                                       
  - Open a protected route with an existing valid session — should go directly through without re-auth   
  
  