### PR TITLE
Fix reactivate button callback data case mismatch

### DIFF
--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -289,7 +289,7 @@ export function createBot(token: string, env: Env): Bot {
     await sendOTPPrompt(ctx, env, telegramId, user.whatsappId, user._id!);
   });
 
-  bot.callbackQuery("reactivate", async ctx => {
+  bot.callbackQuery(/^reactivate$/i, async ctx => {
     await safeAnswerCallbackQuery(ctx);
     const telegramId = ctx.from!.id.toString();
 


### PR DESCRIPTION
## Summary
- The "Reactivate Now" inline button callback was not being handled because the callback data was `"REACTIVATE"` (uppercase) but the grammY handler matched `"reactivate"` (lowercase)
- Changed the handler to use a case-insensitive regex (`/^reactivate$/i`) so it matches both cases

## Root Cause
The uppercase `"REACTIVATE"` callback data was coming from the old pre-Cloudflare Firebase deployment, which is still running in production. The Firebase bot was sending deactivation/reminder messages with uppercase callback data. The old Firebase deployment should be deactivated to prevent further confusion.

## Test plan
- [x] Verified fix by hot-deploying to production and clicking the reactivate button — handler now fires correctly
- [x] Unit tests pass (`pnpm test`)

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)