### PR TITLE
v1.0.3

### DIFF
--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -289,7 +289,7 @@ export function createBot(token: string, env: Env): Bot {
     await sendOTPPrompt(ctx, env, telegramId, user.whatsappId, user._id!);
   });
 
-  bot.callbackQuery("reactivate", async ctx => {
+  bot.callbackQuery(/^reactivate$/i, async ctx => {
     await safeAnswerCallbackQuery(ctx);
     const telegramId = ctx.from!.id.toString();
 


### PR DESCRIPTION
## Summary
- Fix reactivate button not working in production — callback data case mismatch (`REACTIVATE` vs `reactivate`) caused by old Firebase deployment still running. Handler now uses case-insensitive regex match. (#102, closes #99)

## Test plan
- [x] Verified fix by hot-deploying to production and confirming the handler fires
- [x] Unit tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)