### PR TITLE
Fix truthScore persisting on category change

### DIFF
--- a/src/app/api/votes/[voteId]/route.ts
+++ b/src/app/api/votes/[voteId]/route.ts
@@ -55,10 +55,14 @@ export async function POST(req: NextRequest, { params }) {
 
     const filter: Filter<Vote> = { _id: voteId };
 
+    // Only persist truthScore when category is "info"; clear it for other categories
+    const effectiveTruthScore =
+      category === undefined ? truthScore : category === "info" ? truthScore : null;
+
     const update: UpdateFilter<Vote> = {
       $set: {
         ...(category !== undefined && { category }),
-        ...(truthScore !== undefined && { truthScore }),
+        ...(effectiveTruthScore !== undefined && { truthScore: effectiveTruthScore }),
         ...(responseCategory !== undefined && { responseCategory }),
         ...(commentOnResponse !== undefined && { commentOnResponse }),
         ...otherFields,

--- a/src/components/voteContent/VotingSystem.tsx
+++ b/src/components/voteContent/VotingSystem.tsx
@@ -63,6 +63,9 @@ export default function VotingSystem(props: VotingSystemProps) {
 
   const handleVoteCategorySelection = (value: Category) => {
     setVoteCategory(value);
+    if (value !== "info") {
+      setTruthScore(null);
+    }
   };
 
   const handleTruthScoreChange = (value: number | null) => {


### PR DESCRIPTION
## Summary
- Clear `truthScore` state on the frontend when user switches vote category away from "info"
- Strip `truthScore` on the backend when category is explicitly not "info" (defense in depth)

Closes #105

## Test plan
- [ ] Select "info" category, set a truth score, then switch to "scam" — truth score should be cleared
- [ ] Submit a non-info vote and verify no `truthScore` is written to the DB
- [ ] Submit an "info" vote and verify `truthScore` is still persisted correctly
- [ ] Re-vote from "info" to another category and verify truth score is cleared on submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)