### PR TITLE
Merge staging to main

### DIFF
--- a/src/app/api/votes/[voteId]/route.ts
+++ b/src/app/api/votes/[voteId]/route.ts
@@ -55,10 +55,14 @@ export async function POST(req: NextRequest, { params }) {
 
     const filter: Filter<Vote> = { _id: voteId };
 
+    // Only persist truthScore when category is "info"; clear it for other categories
+    const effectiveTruthScore =
+      category === undefined ? truthScore : category === "info" ? truthScore : null;
+
     const update: UpdateFilter<Vote> = {
       $set: {
         ...(category !== undefined && { category }),
-        ...(truthScore !== undefined && { truthScore }),
+        ...(effectiveTruthScore !== undefined && { truthScore: effectiveTruthScore }),
         ...(responseCategory !== undefined && { responseCategory }),
         ...(commentOnResponse !== undefined && { commentOnResponse }),
         ...otherFields,

--- a/src/components/voteContent/VotingSystem.tsx
+++ b/src/components/voteContent/VotingSystem.tsx
@@ -63,6 +63,9 @@ export default function VotingSystem(props: VotingSystemProps) {
 
   const handleVoteCategorySelection = (value: Category) => {
     setVoteCategory(value);
+    if (value !== "info") {
+      setTruthScore(null);
+    }
   };
 
   const handleTruthScoreChange = (value: number | null) => {


### PR DESCRIPTION
## Summary
- Fix truthScore persisting when switching vote category away from info (#105)
- Fix reactivate button not working due to case-insensitive callback data (#102)
- Add R2 image storage with presigned URLs (#100)
- Wrap useSearchParams in Suspense boundary for Next.js 15 (#98)
- Fix deep link auth redirect (#96)
- Update checker-stats endpoint to batch API (#94)
- Rename MONGODB_URI to MONGODB_CONNECTION_STRING (#91)
- Leaderboard improvements and mobile compatibility fixes (#89, #90)
- Fix 30-day stats calculation (#88)
- Fix inactivity handling for pending overdue votes (#87)
- Add test workflow and pre-commit test hook (#86)
- Add take a break / resume checking feature (#85)
- Implement checker programme with graduation flow (#65)
- Merge scam and illicit categories (#69)
- A/B test for community note display order (#68)
- Async event-driven vote assessment (#59)
- Implement leaderboard (#33)
- CI/CD workflows and pnpm monorepo conversion (#46)
- Various bug fixes and infrastructure improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)