### PR TITLE
Remove NLB partnership step from onboarding flow

### DIFF
--- a/shared/types/schema.ts
+++ b/shared/types/schema.ts
@@ -37,7 +37,7 @@ export interface Checker extends BaseDocument {
   onboardingTime: Date | null; // The time the Checker completed the onboarding process
   isQuizComplete: boolean; // Whether the Checker has completed the onboarding quiz
   quizScore: number | null; // The score the Checker got in the quiz
-  onboardingStatus: // The onboarding status of the Checker, either "name", "number", "otpSent", "verify", "quiz", "onboardWhatsapp", "joinGroupChat", "nlb", "completed", or "offboarded"
+  onboardingStatus: // The onboarding status of the Checker, either "name", "number", "otpSent", "verify", "quiz", "onboardWhatsapp", "joinGroupChat", "completed", or "offboarded"
     | "name"
     | "number"
     | "otpSent"
@@ -45,7 +45,6 @@ export interface Checker extends BaseDocument {
     | "quiz"
     | "onboardWhatsapp"
     | "joinGroupChat"
-    | "nlb"
     | "completed"
     | "offboarded";
   hasReceivedExtension: boolean; // Whether the Checker has received the extension for the program

--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -4,7 +4,6 @@ import { getParameters } from "@/shared/helpers/parameters";
 
 import {
   createNewChecker,
-  NLB_SURE_IMAGE,
   normalizePhoneNumber,
   progressBar,
   RESOURCES_MESSAGE,
@@ -226,8 +225,8 @@ export function createBot(token: string, env: Env): Bot {
       const member = await adminBot.api.getChatMember(env.CHECKERS_CHAT_ID, userId);
 
       if (member.status !== "left" && member.status !== "kicked") {
-        // User is in the group
-        await sendNLBPrompt(ctx, env, telegramId);
+        // User is in the group - complete onboarding
+        await sendCompletionPrompt(ctx, env, telegramId);
       } else {
         // User hasn't joined the group yet
         await sendTGGroupPrompt(ctx, env, telegramId, false);
@@ -237,13 +236,6 @@ export function createBot(token: string, env: Env): Bot {
       // On error, show the prompt again (user likely not in group)
       await sendTGGroupPrompt(ctx, env, telegramId, false);
     }
-  });
-
-  bot.callbackQuery("COMPLETED", async ctx => {
-    await safeAnswerCallbackQuery(ctx);
-    const telegramId = ctx.from!.id.toString();
-
-    await sendCompletionPrompt(ctx, env, telegramId);
   });
 
   bot.callbackQuery("ONBOARD_AGAIN", async ctx => {
@@ -409,9 +401,6 @@ async function resumeOnboarding(ctx: Context, env: Env, user: CheckerAPI): Promi
       break;
     case "joinGroupChat":
       await sendTGGroupPrompt(ctx, env, telegramId, true);
-      break;
-    case "nlb":
-      await sendNLBPrompt(ctx, env, telegramId);
       break;
     default:
       await sendNamePrompt(ctx);
@@ -708,19 +697,6 @@ async function sendTGGroupPrompt(
       ),
     }
   );
-}
-
-async function sendNLBPrompt(ctx: Context, env: Env, telegramId: string): Promise<void> {
-  await env.CHECKERS_DB_SERVICE.updateOneChecker(
-    { telegramId },
-    { $set: { onboardingStatus: "nlb", updatedAt: new Date() } }
-  );
-
-  await ctx.replyWithPhoto(NLB_SURE_IMAGE, {
-    caption: `One last thing - CheckMate is partnering with the National Library Board to grow a vibrant learning community aimed at safeguarding the community from scams and misinformation.\n\nIf you'd like to get better at fact-checking, or if you're keen to meet fellow checkers in person, do check out and join the <a href="https://www.nlb.gov.sg/main/site/learnx/explore-communities/explore-communities-content/sure-learning-community">SURE Learning Community</a>. It'll be fun!\n\n${progressBar(6)}`,
-    parse_mode: "HTML",
-    reply_markup: new InlineKeyboard().text("Complete Onboarding", "COMPLETED"),
-  });
 }
 
 async function sendCompletionPrompt(ctx: Context, env: Env, telegramId: string): Promise<void> {

--- a/workers/checkers-webhook-service/src/constants.ts
+++ b/workers/checkers-webhook-service/src/constants.ts
@@ -1,7 +1,3 @@
-// Static assets
-export const NLB_SURE_IMAGE =
-  "https://storage.googleapis.com/checkmate-static-assets/SURE%20Learning%20Community%20Logo%202024.png";
-
 // Resources message
 export const RESOURCES_MESSAGE = `Here are some resources you might find useful:
 1) <a href="https://checkmate.sg">Our official CheckMate website</a>
@@ -14,7 +10,7 @@ export const RESOURCES_MESSAGE = `Here are some resources you might find useful:
 
 // Progress bar helper
 export function progressBar(currentStep: number): string {
-  const totalSteps = 6;
+  const totalSteps = 5;
   let progress = "Onboarding Progress: ";
   for (let i = 0; i < totalSteps; i++) {
     progress += i < currentStep ? "🟩" : "⬜";

--- a/workers/checkers-webhook-service/src/types.ts
+++ b/workers/checkers-webhook-service/src/types.ts
@@ -93,7 +93,6 @@ export interface CheckerAPI {
     | "quiz"
     | "onboardWhatsapp"
     | "joinGroupChat"
-    | "nlb"
     | "completed"
     | "offboarded";
   hasReceivedExtension: boolean;


### PR DESCRIPTION
## Summary
Removes step 6 (NLB Partnership) from the checker onboarding flow as requested in #111.

## Changes
- Update total onboarding steps from 6 to 5
- Remove "nlb" from onboardingStatus type in schema and webhook service
- Update TG_COMPLETED callback to complete onboarding after group join
- Remove COMPLETED callback handler and sendNLBPrompt function
- Remove NLB_SURE_IMAGE constant (no longer needed)

## Impact
Onboarding now completes immediately after checkers join the Telegram group (step 5), without showing the NLB partnership information screen.

## Testing
- All 118 unit tests pass
- Code formatted with prettier via lint-staged

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)