### PR TITLE
Fix category tooltip closing immediately when tapped

### DIFF
--- a/src/components/CategoryTooltip.tsx
+++ b/src/components/CategoryTooltip.tsx
@@ -36,6 +36,8 @@ const CategoryTooltip = ({ category }: CategoryTooltipProps) => {
           type="button"
           className="text-gray-400 hover:text-checkmate-primary cursor-pointer ml-1 inline-flex items-center"
           aria-label={`Help for ${category}`}
+          onClick={e => e.stopPropagation()}
+          onPointerDown={e => e.stopPropagation()}
         >
           <HelpCircle size={14} />
         </button>


### PR DESCRIPTION
The PopoverTrigger button is inside a <Label htmlFor={category}> in
VotePage. Clicking it causes the event to bubble up to the Label,
which triggers focus on the associated RadioGroupItem, causing the
Popover to immediately lose focus and close. Stop propagation on
click and pointerdown events to prevent this.

https://claude.ai/code/session_0135UQYtH7arUwFN1CyraQib