### PR TITLE
Add logging for imageUrl in polls GET endpoint

### DIFF
--- a/src/app/api/polls/[id]/route.ts
+++ b/src/app/api/polls/[id]/route.ts
@@ -27,6 +27,8 @@ export async function GET(req: NextRequest, { params }) {
       poll.imageUrl = await env.PRESIGNED_URL_SERVICE!.generate(poll.imageUrl);
     }
 
+    console.log(`[polls/${id}] imageUrl:`, poll.imageUrl);
+
     return NextResponse.json(poll, { status: 200 });
   } catch (error) {
     return Err.internal();


### PR DESCRIPTION
## Summary
- Logs the `imageUrl` returned by the polls GET endpoint (after pre-signing in staging/prod) for debugging purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)