### PR TITLE
fix: guard checker hooks against empty IDs and fix mobile tooltips

### DIFF
--- a/src/components/common/TooltipwithHelperIcon.tsx
+++ b/src/components/common/TooltipwithHelperIcon.tsx
@@ -2,7 +2,7 @@
 
 import { Info } from "lucide-react";
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
 interface TooltipProps {
   header: string;
@@ -11,25 +11,31 @@ interface TooltipProps {
 
 export default function TooltipWithHelperIcon({ header, text }: TooltipProps) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
+    <Popover>
+      <PopoverTrigger asChild>
         <span
           role="button"
           tabIndex={0}
           aria-label={`${header} help`}
           className="inline-flex items-center rounded-md p-1 text-blue-gray-500 cursor-pointer"
           onClick={e => e.stopPropagation()}
+          onPointerDown={e => e.stopPropagation()}
         >
           <Info />
         </span>
-      </TooltipTrigger>
+      </PopoverTrigger>
 
-      <TooltipContent side="top" align="center" className="p-3">
+      <PopoverContent
+        side="top"
+        align="center"
+        collisionPadding={16}
+        className="max-w-[calc(100vw-32px)] w-64 p-3"
+      >
         <div>
           <h3 className="text-sm font-medium leading-snug text-black">{header}</h3>
           <p className="mt-1 text-sm font-normal text-black/80">{text}</p>
         </div>
-      </TooltipContent>
-    </Tooltip>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/hooks/checkers/useGetCheckersDetails.ts
+++ b/src/hooks/checkers/useGetCheckersDetails.ts
@@ -15,5 +15,6 @@ export function useGetCheckersById(checkerId: string) {
       const resp = await checkersAPI.checkersDetail(checkerId);
       return resp?.data;
     },
+    enabled: !!checkerId,
   });
 }

--- a/src/hooks/checkers/useGetCheckersProgramme.ts
+++ b/src/hooks/checkers/useGetCheckersProgramme.ts
@@ -8,5 +8,6 @@ export function useGetCheckersProgrammeById(checkerId: string) {
       const resp = await checkersAPI.programmeDetail(checkerId);
       return resp?.data;
     },
+    enabled: !!checkerId,
   });
 }

--- a/src/hooks/checkers/useGetCheckersStats.ts
+++ b/src/hooks/checkers/useGetCheckersStats.ts
@@ -8,5 +8,6 @@ export function useGetCheckersStatsById(checkerId: string) {
       const resp = await checkersAPI.statsDetail(checkerId);
       return resp?.data;
     },
+    enabled: !!checkerId,
   });
 }


### PR DESCRIPTION
## Summary
- Add `enabled: !!checkerId` to `useGetCheckersById`, `useGetCheckersProgrammeById`, and `useGetCheckersStatsById` to prevent queries firing before session loads — an empty string was normalising to `/api/checkers/programme`, which Next.js captured as a `checkerId`, causing a BSONError
- Switch `TooltipWithHelperIcon` from Radix `Tooltip` to `Popover` so category tooltips respond to tap in the Telegram MiniApp (Tooltip is hover-only and never fires on mobile)

## Test plan
- [ ] Open the app before session loads — no BSONError in worker logs
- [ ] Tap the info icon on a vote category — tooltip popover opens correctly on mobile
- [ ] All 118 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)