### PR TITLE
feat: rewrite group chat onboarding step to foster community spirit

### DIFF
--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -717,10 +717,11 @@ async function sendTGGroupPrompt(
     );
   }
 
+  const firstPromptMessage = `You're now part of the CheckMate Checker community, a network fighting misinformation together!\n\nJoin our <a href="${env.CHECKERS_GROUP_LINK}">group chat</a> to connect with fellow checkers here.\n\nIn this group chat, you'll get system updates, shared fact-checking resources, and see our collective impact.\n\nImportant: Keep your votes independent, but lean on the community for support and resources.\n\nWelcome to the team 😀!\n\n${progressBar(5)}`;
+  const retryMessage = `We noticed you have not joined the group chat yet. Join our <a href="${env.CHECKERS_GROUP_LINK}">group chat</a> to connect with fellow checkers and be part of our mission to fight misinformation together!\n\n${progressBar(5)}`;
+
   await ctx.reply(
-    `${
-      isFirstPrompt ? "Next, p" : "We noticed you have not joined the groupchat yet. P"
-    }lease join the <a href="${env.CHECKERS_GROUP_LINK}">CheckMate Checker's groupchat</a>. This group chat is important as it will be used to:\n\n1) Inform checkers of any downtime in the system, updates/improvements being deployed to the bots\n\n2) Share relevant links from reputable news sources to aid fact-checking. Do note that beyond this, checkers should not discuss what to vote, as this may make the collective outcome biased.\n\n${progressBar(5)}`,
+    isFirstPrompt ? firstPromptMessage : retryMessage,
     {
       parse_mode: "HTML",
       reply_markup: new InlineKeyboard().text(


### PR DESCRIPTION
Updated the Telegram group chat onboarding step copy to be more welcoming and emphasize shared mission, replacing the functional/informational copy with community-focused messaging.

Closes #132

Generated with [Claude Code](https://claude.ai/code)