### PR TITLE
feat: update /start welcome message for new checkers

### DIFF
--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -36,7 +36,13 @@ export function createBot(token: string, env: Env): Bot {
 
     if (!existingUser) {
       await ctx.reply(
-        `Welcome to your personal CheckMate Checker's bot! 🎉\nThis is where you'll review messages, view your statistics etc.`,
+        `Hello!! 🥳
+
+You're about to become part of a team fighting misinformation.
+
+We'll walk you through a simple onboarding process to help you become a skilled fact-seeker.
+
+By the end, you'll be ready to make your first check and join CheckMate in action.`,
         {
           reply_markup: new InlineKeyboard().text("Let's go!", "START_ONBOARD"),
         }
@@ -720,16 +726,13 @@ async function sendTGGroupPrompt(
   const firstPromptMessage = `You're now part of the CheckMate Checker community, a network fighting misinformation together!\n\nJoin our <a href="${env.CHECKERS_GROUP_LINK}">group chat</a> to connect with fellow checkers here.\n\nIn this group chat, you'll get system updates, shared fact-checking resources, and see our collective impact.\n\nImportant: Keep your votes independent, but lean on the community for support and resources.\n\nWelcome to the team 😀!\n\n${progressBar(5)}`;
   const retryMessage = `We noticed you have not joined the group chat yet. Join our <a href="${env.CHECKERS_GROUP_LINK}">group chat</a> to connect with fellow checkers and be part of our mission to fight misinformation together!\n\n${progressBar(5)}`;
 
-  await ctx.reply(
-    isFirstPrompt ? firstPromptMessage : retryMessage,
-    {
-      parse_mode: "HTML",
-      reply_markup: new InlineKeyboard().text(
-        "Yes, I have joined the Telegram Chat Group",
-        "TG_COMPLETED"
-      ),
-    }
-  );
+  await ctx.reply(isFirstPrompt ? firstPromptMessage : retryMessage, {
+    parse_mode: "HTML",
+    reply_markup: new InlineKeyboard().text(
+      "Yes, I have joined the Telegram Chat Group",
+      "TG_COMPLETED"
+    ),
+  });
 }
 
 async function sendCompletionPrompt(ctx: Context, env: Env, telegramId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Updated the `/start` welcome message for new users to be more engaging and explain the onboarding journey
- Minor formatting cleanup in `sendTGGroupPrompt`

## Test plan
- [ ] Send `/start` to the bot as a new user and verify the updated message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)