### PR TITLE
fix: trigger programme graduation when final milestone is reports

### DIFF
--- a/workers/checkers-event-handler-service/src/handlers/scheduled/graduation.ts
+++ b/workers/checkers-event-handler-service/src/handlers/scheduled/graduation.ts
@@ -1,0 +1,49 @@
+import { checkGraduation } from "@/shared/helpers/checkGraduation";
+
+/**
+ * Daily sweep: re-evaluate graduation for all active/extended programmes.
+ *
+ * Needed because graduation is otherwise only triggered by `vote.scoreChanged`,
+ * which doesn't fire when the crossing target is reports (reports live in the
+ * WhatsApp service and don't produce events here). Running this before the
+ * programme extension/offboarding cron ensures eligible checkers graduate
+ * instead of being offboarded at day 90.
+ */
+export async function runGraduationSweep(env: Env): Promise<void> {
+  console.log("Running graduation sweep...");
+
+  const result = await env.CHECKERS_DB_SERVICE.findProgrammes({
+    status: { $in: ["active", "extended"] },
+  });
+
+  if (!result.success || !result.data) {
+    console.error(`Graduation sweep: failed to fetch programmes: ${result.error}`);
+    return;
+  }
+
+  let graduated = 0;
+  let errored = 0;
+
+  for (const programme of result.data) {
+    try {
+      const gradResult = await checkGraduation(env, programme.checkerId);
+      if (!gradResult.success) {
+        errored++;
+        console.error(
+          `Graduation sweep error for checker ${programme.checkerId}: ${gradResult.error}`
+        );
+        continue;
+      }
+      if (gradResult.graduated) {
+        graduated++;
+      }
+    } catch (err) {
+      errored++;
+      console.error(`Graduation sweep exception for checker ${programme.checkerId}:`, err);
+    }
+  }
+
+  console.log(
+    `Graduation sweep complete: scanned ${result.data.length}, graduated ${graduated}, errored ${errored}`
+  );
+}

--- a/workers/checkers-event-handler-service/src/index.ts
+++ b/workers/checkers-event-handler-service/src/index.ts
@@ -6,6 +6,7 @@ import { handlePrimaryCategoryChanged } from "./handlers/queue/onPrimaryCategory
 import { handleProgrammeCompletion } from "./handlers/queue/onProgrammeCompletion";
 import { handleVoteScoreChange } from "./handlers/queue/onVoteScoreChange";
 import { handleVoteSubmitted } from "./handlers/queue/onVoteSubmitted";
+import { runGraduationSweep } from "./handlers/scheduled/graduation";
 import { runInactivityChecks } from "./handlers/scheduled/inactivity";
 import { runProgrammeChecks } from "./handlers/scheduled/programme";
 import { runWeeklyWelcomeMessage } from "./handlers/scheduled/welcomeMessage";
@@ -116,6 +117,11 @@ export default class extends WorkerEntrypoint<Env> {
     const cron = event.cron;
 
     console.log(`Batch job triggered by cron: ${cron}`);
+
+    // 10:30 AM SGT (2:30 UTC) - Graduation sweep
+    if (cron === "30 2 * * *") {
+      await runGraduationSweep(this.env);
+    }
 
     // 8:11 PM SGT (12:11 UTC) - Inactivity checks
     if (cron === "11 12 * * *") {

--- a/workers/checkers-event-handler-service/wrangler.jsonc
+++ b/workers/checkers-event-handler-service/wrangler.jsonc
@@ -13,11 +13,12 @@
   },
   /**
    * Cron Triggers
+   * Run graduation sweep at 10:30 AM SGT (2:30 UTC)
    * Run inactivity checks at 8:11 PM SGT (12:11 UTC)
    * Run programme checks at 8:41 PM SGT (12:41 UTC)
    */
   "triggers": {
-    "crons": ["11 12 * * *", "41 12 * * *", "0 4 * * 2"],
+    "crons": ["30 2 * * *", "11 12 * * *", "41 12 * * *", "0 4 * * 2"],
   },
   /**
    * Dev configuration

--- a/workers/checkers-webhook-service/src/check-graduation.ts
+++ b/workers/checkers-webhook-service/src/check-graduation.ts
@@ -1,0 +1,39 @@
+import { Context } from "hono";
+
+import { checkGraduation } from "@/shared/helpers/checkGraduation";
+
+export async function handleCheckGraduation(c: Context<{ Bindings: Env }>) {
+  const env = c.env;
+
+  const apiKey = c.req.header("x-api-key");
+  if (!apiKey || apiKey !== env.API_KEY) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  try {
+    const body = await c.req.json<{ whatsappId: string }>();
+
+    if (!body.whatsappId || typeof body.whatsappId !== "string") {
+      return c.json({ error: "Missing 'whatsappId' in request body" }, 400);
+    }
+
+    const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({
+      whatsappId: body.whatsappId,
+    });
+
+    if (!checkerResult.success || !checkerResult.data) {
+      return c.json({ success: false, error: "Checker not found" }, 404);
+    }
+
+    const result = await checkGraduation(env, checkerResult.data._id!);
+
+    if (!result.success) {
+      return c.json({ success: false, error: result.error }, 500);
+    }
+
+    return c.json({ success: true, graduated: result.graduated ?? false });
+  } catch (err) {
+    console.error("[CHECK-GRADUATION ERROR]", err);
+    return c.json({ error: "Server error" }, 500);
+  }
+}

--- a/workers/checkers-webhook-service/src/check-graduation.ts
+++ b/workers/checkers-webhook-service/src/check-graduation.ts
@@ -25,6 +25,10 @@ export async function handleCheckGraduation(c: Context<{ Bindings: Env }>) {
       return c.json({ success: false, error: "Checker not found" }, 404);
     }
 
+    if (!checkerResult.data.currentProgrammeId) {
+      return c.json({ success: false, error: "Checker has no active programme" }, 404);
+    }
+
     const result = await checkGraduation(env, checkerResult.data._id!);
 
     if (!result.success) {

--- a/workers/checkers-webhook-service/src/index.ts
+++ b/workers/checkers-webhook-service/src/index.ts
@@ -5,6 +5,7 @@ import { createBot } from "./bot";
 import { handleTypeformWebhook } from "./typeform";
 import { handlePollWebhook } from "./polls";
 import { handleCheckerStatsWebhook } from "./checker-stats";
+import { handleCheckGraduation } from "./check-graduation";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -40,6 +41,9 @@ app.post("/polls/webhook", handlePollWebhook);
 
 // Checker stats endpoint for ops automation (batch)
 app.post("/checker-stats", handleCheckerStatsWebhook);
+
+// Admin: manually trigger graduation check for a checker (by whatsappId)
+app.post("/admin/check-graduation", handleCheckGraduation);
 
 export default class extends WorkerEntrypoint<Env> {
   async fetch(request: Request) {


### PR DESCRIPTION
## Summary
- Adds `POST /admin/check-graduation` on `checkers-webhook-service` (x-api-key auth) to manually trigger graduation for a checker by `whatsappId`.
- Adds a daily cron sweep at 10:30 AM SGT (02:30 UTC) on `checkers-event-handler-service` that re-evaluates graduation for all `active`+`extended` programmes.

## Why
Graduation was only triggered by `vote.scoreChanged` events. Since reports are owned by the sibling WhatsApp service with no event hook back into this repo, checkers whose last crossed milestone was reports were never graduated — they got offboarded at day 90 without a certificate and without `hasCompletedProgramme` being set. The sweep gives us a proactive re-check; the admin endpoint gives ops a manual recovery path.

Both callers use the existing `shared/helpers/checkGraduation.ts`, which previously had no production callers (only tests).

The 10:30 AM sweep runs ~10 hours before the 8:41 PM offboarding cron — plenty of time for the `programme.completed` queue event to be processed and status updated to `"completed"` so the programme drops out of the offboarding query.

## Test plan
- [x] Unit tests pass (`pnpm test` — 118/118)
- [x] No new TypeScript errors
- [ ] Verify admin endpoint auth and payload handling on staging with a real `whatsappId`
- [ ] Confirm cron schedule registered on staging deploy
- [ ] Manually trigger endpoint for the stuck extended checker; verify `programme.completed` queue event fires and cert is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)