### PR TITLE
fix: include stats in programme.completed event

### DIFF
--- a/shared/helpers/checkGraduation.ts
+++ b/shared/helpers/checkGraduation.ts
@@ -69,6 +69,11 @@ export async function checkGraduation(
       data: {
         checkerId,
         programmeId: checkerResult.data.currentProgrammeId,
+        stats: {
+          voteCount: checkersProgress.data.voteCount,
+          accuracy: checkersProgress.data.accuracy ?? 0,
+          reportCount: checkersProgress.data.reportCount,
+        },
       },
       timestamp: new Date().toISOString(),
     });

--- a/tests/unit/checkGraduation.test.ts
+++ b/tests/unit/checkGraduation.test.ts
@@ -360,6 +360,11 @@ describe("checkGraduation", () => {
           data: {
             checkerId: "checker-001",
             programmeId: "programme-001",
+            stats: {
+              voteCount: expect.any(Number),
+              accuracy: expect.any(Number),
+              reportCount: expect.any(Number),
+            },
           },
           timestamp: expect.any(String),
         })

--- a/workers/checkers-event-handler-service/src/handlers/queue/onVoteScoreChange.ts
+++ b/workers/checkers-event-handler-service/src/handlers/queue/onVoteScoreChange.ts
@@ -1,5 +1,6 @@
 import { Bot } from "grammy";
 
+import { checkGraduation } from "@/shared/helpers/checkGraduation";
 import { calculateProgrammeProgress } from "@/lib/helpers/programmeProgress";
 import { getParameters } from "@/shared/helpers/parameters";
 
@@ -60,8 +61,8 @@ export async function handleVoteScoreChange(env: Env, data: VoteScoreChangedData
   // 1. Check accuracy nudge conditions
   await checkAccuracyNudge(env, checker, programme, progress);
 
-  // 2. Check graduation conditions
-  await checkGraduation(env, checker, programme, progress);
+  // 2. Check graduation conditions (re-fetches; cheap and keeps single source of truth)
+  await checkGraduation(env, checkerId);
 }
 
 /**
@@ -141,48 +142,4 @@ async function checkAccuracyNudge(
     { _id: programme._id },
     { $set: { hasReceivedLowAccuracyWarning: true } }
   );
-}
-
-/**
- * Check if checker has met all programme targets and should graduate
- * If graduated, emits a "programme.completed" event for async processing
- */
-async function checkGraduation(
-  env: Env,
-  checker: { _id: string; currentProgrammeId: string | null },
-  programme: { _id: string; targets: { votes: number; accuracy: number; reports: number } },
-  progress: { voteCount: number; accuracy: number | null; reportCount: number }
-): Promise<void> {
-  console.log("Checking graduation conditions");
-  // Check vote count threshold
-  if (progress.voteCount < programme.targets.votes) {
-    return;
-  }
-
-  // Check accuracy threshold
-  if ((progress.accuracy ?? 0) < programme.targets.accuracy) {
-    return;
-  }
-
-  // Check reports threshold
-  if (progress.reportCount < programme.targets.reports) {
-    return;
-  }
-
-  // All targets met - emit graduation event for async processing
-  await env.CHECKERS_EVENTS_QUEUE.send({
-    type: "programme.completed",
-    data: {
-      checkerId: checker._id,
-      programmeId: programme._id,
-      stats: {
-        voteCount: progress.voteCount,
-        accuracy: progress.accuracy ?? 0,
-        reportCount: progress.reportCount,
-      },
-    },
-    timestamp: new Date().toISOString(),
-  });
-
-  console.log(`Emitted programme.completed event for checker ${checker._id}`);
 }


### PR DESCRIPTION
## Summary
Follow-up fix to #149. The shared `checkGraduation` helper was emitting the `programme.completed` event without the `stats` field, which caused a `TypeError: Cannot read properties of undefined (reading 'voteCount')` when `onProgrammeCompletion` tried to send the graduation Telegram message.

## Impact of the original bug
The TypeError is thrown in step 6 of `onProgrammeCompletion` (sending the Telegram congratulations message), after the DB state has already been updated and the certificate generated. So affected checkers **are** graduated — `hasCompletedProgramme: true`, `status: "completed"`, certificate in R2 — they just didn't receive the congratulations Telegram message.

## Changes
- `shared/helpers/checkGraduation.ts` now includes `stats: { voteCount, accuracy, reportCount }` in the emitted event, matching `ProgrammeCompletedData`.
- Removed the duplicate local `checkGraduation` function in `onVoteScoreChange.ts` and switched it to the shared helper — the duplication is what let the two versions drift.
- Updated `tests/unit/checkGraduation.test.ts` to assert the `stats` shape.

## Test plan
- [x] `pnpm test` passes (118/118)
- [ ] Re-trigger admin endpoint / next daily sweep and confirm congratulations message is delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)