### PR TITLE
feat: let graduates confirm cert name via claim miniapp (#153)

### DIFF
--- a/shared/types/schema.ts
+++ b/shared/types/schema.ts
@@ -130,6 +130,7 @@ export interface Programme extends BaseDocument {
   hasReceivedExtension: boolean; // Whether Day 60 extension notice was sent
   hasReceivedLowAccuracyWarning: boolean; // Whether low accuracy warning was sent
   certificateUrl: string | null; // URL to the generated certificate
+  certificateName: string | null; // Name the checker chose to appear on the certificate
   completedAt: Date | null; // When the checker graduated
 }
 

--- a/src/app/api/checkers/[checkerId]/certificate/route.ts
+++ b/src/app/api/checkers/[checkerId]/certificate/route.ts
@@ -2,11 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { auth } from "@/auth";
 import { Err } from "@/lib/api/error";
+import { MAX_CERT_NAME_LEN, MIN_CERT_NAME_LEN } from "@/lib/constants/certificate";
 import { publishCheckersEvent } from "@/lib/helpers/events/publishCheckersEvent";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-
-const MIN_NAME_LEN = 1;
-const MAX_NAME_LEN = 100;
 
 export async function POST(req: NextRequest, { params }) {
   const { env } = getCloudflareContext();
@@ -23,8 +21,10 @@ export async function POST(req: NextRequest, { params }) {
     const body = (await req.json().catch(() => null)) as { name?: unknown } | null;
     const rawName = typeof body?.name === "string" ? body.name : "";
     const name = rawName.replace(/[\p{Cc}\p{Cn}]/gu, "").trim();
-    if (name.length < MIN_NAME_LEN || name.length > MAX_NAME_LEN) {
-      return Err.badParams(`Name must be between ${MIN_NAME_LEN} and ${MAX_NAME_LEN} characters`);
+    if (name.length < MIN_CERT_NAME_LEN || name.length > MAX_CERT_NAME_LEN) {
+      return Err.badParams(
+        `Name must be between ${MIN_CERT_NAME_LEN} and ${MAX_CERT_NAME_LEN} characters`
+      );
     }
 
     // Find the checker's most recent completed programme that doesn't yet have a certificate.

--- a/src/app/api/checkers/[checkerId]/certificate/route.ts
+++ b/src/app/api/checkers/[checkerId]/certificate/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { auth } from "@/auth";
+import { Err } from "@/lib/api/error";
+import { publishCheckersEvent } from "@/lib/helpers/events/publishCheckersEvent";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+const MIN_NAME_LEN = 1;
+const MAX_NAME_LEN = 100;
+
+export async function POST(req: NextRequest, { params }) {
+  const { env } = getCloudflareContext();
+
+  try {
+    const session = await auth();
+    if (!session?.user) return Err.unauthorized();
+
+    const { checkerId } = await params;
+    if (!checkerId) return Err.badParams("Missing checkerId parameter");
+
+    if (session.user.id !== checkerId) return Err.forbidden();
+
+    const body = (await req.json().catch(() => null)) as { name?: unknown } | null;
+    const rawName = typeof body?.name === "string" ? body.name : "";
+    const name = rawName.replace(/[\p{Cc}\p{Cn}]/gu, "").trim();
+    if (name.length < MIN_NAME_LEN || name.length > MAX_NAME_LEN) {
+      return Err.badParams(`Name must be between ${MIN_NAME_LEN} and ${MAX_NAME_LEN} characters`);
+    }
+
+    // Find the checker's most recent completed programme that doesn't yet have a certificate.
+    const programmesResult = await env.CHECKERS_DB_SERVICE.findProgrammes(
+      { checkerId, status: "completed", certificateUrl: null },
+      { sort: { completedAt: -1 } }
+    );
+
+    const pendingProgramme = programmesResult.data?.[0];
+    if (!programmesResult.success || !pendingProgramme?._id) {
+      return Err.notFound("No pending certificate to claim");
+    }
+
+    const updateResult = await env.CHECKERS_DB_SERVICE.updateOneProgramme(
+      { _id: pendingProgramme._id, certificateUrl: null },
+      { $set: { certificateName: name } }
+    );
+    if (!updateResult.success) {
+      return Err.internal("Failed to store certificate name");
+    }
+    if (updateResult.modifiedCount === 0) {
+      return Err.conflict("Certificate has already been issued");
+    }
+
+    const publishResult = await publishCheckersEvent(env, {
+      type: "certificate.requested",
+      data: { checkerId, programmeId: pendingProgramme._id },
+      timestamp: new Date().toISOString(),
+    });
+    if (!publishResult.success) {
+      return Err.internal("Failed to queue certificate generation");
+    }
+
+    return NextResponse.json({ status: "queued" }, { status: 202 });
+  } catch (error) {
+    console.error("Error claiming certificate:", error);
+    return Err.internal();
+  }
+}

--- a/src/app/api/checkers/[checkerId]/programme/route.ts
+++ b/src/app/api/checkers/[checkerId]/programme/route.ts
@@ -136,6 +136,7 @@ export async function POST(req: NextRequest, { params }) {
       hasReceivedExtension: false,
       hasReceivedLowAccuracyWarning: false,
       certificateUrl: null,
+      certificateName: null,
       completedAt: null,
     });
 

--- a/src/app/graduation/claim/ClaimCertificateForm.tsx
+++ b/src/app/graduation/claim/ClaimCertificateForm.tsx
@@ -5,13 +5,12 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { MAX_CERT_NAME_LEN } from "@/lib/constants/certificate";
 
 interface Props {
   checkerId: string;
   initialName: string;
 }
-
-const MAX_NAME_LEN = 100;
 
 export function ClaimCertificateForm({ checkerId, initialName }: Props) {
   const [name, setName] = useState(initialName);
@@ -67,7 +66,7 @@ export function ClaimCertificateForm({ checkerId, initialName }: Props) {
           id="cert-name"
           value={name}
           onChange={e => setName(e.target.value)}
-          maxLength={MAX_NAME_LEN}
+          maxLength={MAX_CERT_NAME_LEN}
           required
           disabled={submitting}
         />

--- a/src/app/graduation/claim/ClaimCertificateForm.tsx
+++ b/src/app/graduation/claim/ClaimCertificateForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  checkerId: string;
+  initialName: string;
+}
+
+const MAX_NAME_LEN = 100;
+
+export function ClaimCertificateForm({ checkerId, initialName }: Props) {
+  const [name, setName] = useState(initialName);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Please enter a name.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/checkers/${checkerId}/certificate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
+        throw new Error(body.message || "Failed to submit");
+      }
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="p-6 max-w-md mx-auto flex flex-col gap-4">
+        <h1 className="text-xl font-semibold">Thanks!</h1>
+        <p className="text-sm text-gray-600">
+          We're preparing your certificate — you'll get a Telegram message shortly with the link and
+          a LinkedIn share button.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-6 max-w-md mx-auto flex flex-col gap-4">
+      <h1 className="text-xl font-semibold">Claim your certificate</h1>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="cert-name">This name will appear on your certificate.</Label>
+        <Input
+          id="cert-name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          maxLength={MAX_NAME_LEN}
+          required
+          disabled={submitting}
+        />
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <Button type="submit" disabled={submitting || !name.trim()}>
+        {submitting ? "Submitting…" : "Issue my certificate"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/graduation/claim/page.tsx
+++ b/src/app/graduation/claim/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+import { ClaimCertificateForm } from "./ClaimCertificateForm";
+
+export default async function ClaimCertificatePage() {
+  const session = await auth();
+  if (!session?.user) redirect("/unauthorized");
+
+  const { env } = getCloudflareContext();
+
+  const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({ _id: session.user.id });
+  const checker = checkerResult.data;
+
+  if (!checker || !checker.hasCompletedProgramme) {
+    redirect("/dashboard");
+  }
+
+  // Look for a completed programme still awaiting a certificate.
+  const pendingResult = await env.CHECKERS_DB_SERVICE.findProgrammes(
+    { checkerId: session.user.id, status: "completed", certificateUrl: null },
+    { sort: { completedAt: -1 } }
+  );
+  const pendingProgramme = pendingResult.data?.[0];
+
+  if (!pendingProgramme) {
+    // Either never graduated or certificate already issued — show the existing cert if any.
+    if (checker.certificateUrl) {
+      return (
+        <div className="p-6 max-w-md mx-auto flex flex-col gap-4">
+          <h1 className="text-xl font-semibold">Your certificate is ready</h1>
+          <p className="text-sm text-gray-600">
+            You've already claimed your certificate. You can view it below.
+          </p>
+          <a
+            href={checker.certificateUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex justify-center rounded-md bg-primary px-4 py-2 text-primary-foreground"
+          >
+            View your certificate
+          </a>
+        </div>
+      );
+    }
+    redirect("/dashboard");
+  }
+
+  return <ClaimCertificateForm checkerId={session.user.id} initialName={checker.name ?? ""} />;
+}

--- a/src/lib/constants/certificate.ts
+++ b/src/lib/constants/certificate.ts
@@ -1,0 +1,2 @@
+export const MIN_CERT_NAME_LEN = 1;
+export const MAX_CERT_NAME_LEN = 100;

--- a/tests/unit/certificateRoute.test.ts
+++ b/tests/unit/certificateRoute.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/helpers/events/publishCheckersEvent", () => ({
+  publishCheckersEvent: vi.fn(),
+}));
+vi.mock("@opennextjs/cloudflare", () => ({ getCloudflareContext: vi.fn() }));
+
+import { POST } from "@/app/api/checkers/[checkerId]/certificate/route";
+import { auth } from "@/auth";
+import { publishCheckersEvent } from "@/lib/helpers/events/publishCheckersEvent";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+const mockFindProgrammes = vi.fn();
+const mockUpdateOneProgramme = vi.fn();
+
+const mockEnv = {
+  CHECKERS_DB_SERVICE: {
+    findProgrammes: mockFindProgrammes,
+    updateOneProgramme: mockUpdateOneProgramme,
+  },
+};
+
+function buildRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/checkers/checker-001/certificate", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("POST /api/checkers/[checkerId]/certificate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: "checker-001", telegramId: "123456", name: "Alice" },
+      expires: new Date(Date.now() + 86400000).toISOString(),
+    });
+    vi.mocked(getCloudflareContext).mockReturnValue({ env: mockEnv } as any);
+
+    mockFindProgrammes.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          _id: "programme-001",
+          status: "completed",
+          certificateUrl: null,
+          completedAt: new Date("2026-04-01"),
+        },
+      ],
+    });
+    mockUpdateOneProgramme.mockResolvedValue({ success: true, modifiedCount: 1 });
+    vi.mocked(publishCheckersEvent).mockResolvedValue({ success: true });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(auth).mockResolvedValue(null);
+    const res = await POST(buildRequest({ name: "Alice" }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the session user is not the target checker", async () => {
+    const res = await POST(buildRequest({ name: "Alice" }), {
+      params: Promise.resolve({ checkerId: "another-checker" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects empty names", async () => {
+    const res = await POST(buildRequest({ name: "   " }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(400);
+    expect(mockUpdateOneProgramme).not.toHaveBeenCalled();
+  });
+
+  it("rejects names longer than 100 characters", async () => {
+    const res = await POST(buildRequest({ name: "a".repeat(101) }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the checker has no pending completed programme", async () => {
+    mockFindProgrammes.mockResolvedValue({ success: true, data: [] });
+    const res = await POST(buildRequest({ name: "Alice Smith" }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(404);
+    expect(mockUpdateOneProgramme).not.toHaveBeenCalled();
+  });
+
+  it("queues a certificate.requested event on success", async () => {
+    const res = await POST(buildRequest({ name: "  Alice Smith  " }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(mockFindProgrammes).toHaveBeenCalledWith(
+      { checkerId: "checker-001", status: "completed", certificateUrl: null },
+      { sort: { completedAt: -1 } }
+    );
+    expect(mockUpdateOneProgramme).toHaveBeenCalledWith(
+      { _id: "programme-001", certificateUrl: null },
+      { $set: { certificateName: "Alice Smith" } }
+    );
+    expect(publishCheckersEvent).toHaveBeenCalledWith(
+      mockEnv,
+      expect.objectContaining({
+        type: "certificate.requested",
+        data: { checkerId: "checker-001", programmeId: "programme-001" },
+      })
+    );
+  });
+
+  it("returns 409 if the programme was already claimed (race)", async () => {
+    mockUpdateOneProgramme.mockResolvedValue({ success: true, modifiedCount: 0 });
+    const res = await POST(buildRequest({ name: "Alice Smith" }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 500 if publishing the event fails", async () => {
+    vi.mocked(publishCheckersEvent).mockResolvedValue({ success: false, error: "queue down" });
+    const res = await POST(buildRequest({ name: "Alice Smith" }), {
+      params: Promise.resolve({ checkerId: "checker-001" }),
+    });
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/onCertificateRequested.test.ts
+++ b/tests/unit/onCertificateRequested.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendMessageMock, generateCertificateMock, generateLinkedInCredentialUrlMock } = vi.hoisted(
+  () => ({
+    sendMessageMock: vi.fn(),
+    generateCertificateMock: vi.fn(),
+    generateLinkedInCredentialUrlMock: vi.fn(),
+  })
+);
+
+vi.mock("grammy", () => ({
+  Bot: class {
+    api = { sendMessage: sendMessageMock };
+  },
+}));
+
+vi.mock("../../workers/checkers-event-handler-service/src/helpers/generateCertificate", () => ({
+  generateCertificate: generateCertificateMock,
+}));
+
+vi.mock("../../workers/checkers-event-handler-service/src/helpers/linkedInCredential", () => ({
+  generateLinkedInCredentialUrl: generateLinkedInCredentialUrlMock,
+}));
+
+import { handleCertificateRequested } from "../../workers/checkers-event-handler-service/src/handlers/queue/onCertificateRequested";
+
+const mockFindOneChecker = vi.fn();
+const mockFindOneProgramme = vi.fn();
+const mockUpdateOneChecker = vi.fn();
+const mockUpdateOneProgramme = vi.fn();
+
+const env = {
+  TELEGRAM_BOT_TOKEN: "test-bot",
+  LINKEDIN_ORG_ID: "42",
+  CHECKERS_DB_SERVICE: {
+    findOneChecker: mockFindOneChecker,
+    findOneProgramme: mockFindOneProgramme,
+    updateOneChecker: mockUpdateOneChecker,
+    updateOneProgramme: mockUpdateOneProgramme,
+  },
+} as unknown as Env;
+
+const data = { checkerId: "checker-001", programmeId: "programme-001" };
+
+const baseProgramme = {
+  _id: "programme-001",
+  certificateUrl: null,
+  certificateName: "Alice Smith",
+  completedAt: new Date("2026-04-01"),
+  targets: { votes: 50, accuracy: 60, reports: 10 },
+};
+
+describe("handleCertificateRequested", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindOneChecker.mockResolvedValue({
+      success: true,
+      data: { _id: "checker-001", name: "Alice", telegramId: "123456" },
+    });
+    mockFindOneProgramme.mockResolvedValue({ success: true, data: baseProgramme });
+    mockUpdateOneProgramme.mockResolvedValue({ success: true, modifiedCount: 1 });
+    mockUpdateOneChecker.mockResolvedValue({ success: true, modifiedCount: 1 });
+    generateCertificateMock.mockResolvedValue({
+      success: true,
+      url: "https://r2.example/programme-001.html",
+    });
+    generateLinkedInCredentialUrlMock.mockReturnValue("https://linkedin.example/cred");
+    sendMessageMock.mockResolvedValue(undefined);
+  });
+
+  it("generates the certificate using programme.certificateName", async () => {
+    await handleCertificateRequested(env, data);
+
+    expect(generateCertificateMock).toHaveBeenCalledWith(env, {
+      userName: "Alice Smith",
+      programmeId: "programme-001",
+      targets: baseProgramme.targets,
+    });
+  });
+
+  it("writes certificateUrl to both programme and checker", async () => {
+    await handleCertificateRequested(env, data);
+
+    expect(mockUpdateOneProgramme).toHaveBeenCalledWith(
+      { _id: "programme-001" },
+      { $set: { certificateUrl: "https://r2.example/programme-001.html" } }
+    );
+    expect(mockUpdateOneChecker).toHaveBeenCalledWith(
+      { _id: "checker-001" },
+      { $set: { certificateUrl: "https://r2.example/programme-001.html" } }
+    );
+  });
+
+  it("sends the certificate-ready Telegram message with both buttons", async () => {
+    await handleCertificateRequested(env, data);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const [, , options] = sendMessageMock.mock.calls[0];
+    const buttons = options.reply_markup.inline_keyboard[0];
+    expect(buttons).toEqual([
+      { text: "View your certificate!", url: "https://r2.example/programme-001.html" },
+      { text: "Add certificate to LinkedIn", url: "https://linkedin.example/cred" },
+    ]);
+  });
+
+  it("skips generation if programme already has a certificateUrl", async () => {
+    mockFindOneProgramme.mockResolvedValue({
+      success: true,
+      data: { ...baseProgramme, certificateUrl: "https://existing.example/cert.html" },
+    });
+
+    await handleCertificateRequested(env, data);
+
+    expect(generateCertificateMock).not.toHaveBeenCalled();
+    expect(mockUpdateOneProgramme).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to generate if certificateName is missing", async () => {
+    mockFindOneProgramme.mockResolvedValue({
+      success: true,
+      data: { ...baseProgramme, certificateName: null },
+    });
+
+    await handleCertificateRequested(env, data);
+
+    expect(generateCertificateMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts without updating fields if cert generation fails", async () => {
+    generateCertificateMock.mockResolvedValue({ success: false, error: "R2 down" });
+
+    await handleCertificateRequested(env, data);
+
+    expect(mockUpdateOneProgramme).not.toHaveBeenCalled();
+    expect(mockUpdateOneChecker).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/onProgrammeCompletion.test.ts
+++ b/tests/unit/onProgrammeCompletion.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendMessageMock, generateCertificateMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(),
+  generateCertificateMock: vi.fn(),
+}));
+
+vi.mock("grammy", () => ({
+  Bot: class {
+    api = { sendMessage: sendMessageMock };
+  },
+}));
+
+vi.mock("../../workers/checkers-event-handler-service/src/helpers/generateCertificate", () => ({
+  generateCertificate: generateCertificateMock,
+}));
+
+import { handleProgrammeCompletion } from "../../workers/checkers-event-handler-service/src/handlers/queue/onProgrammeCompletion";
+
+const mockFindOneChecker = vi.fn();
+const mockUpdateOneChecker = vi.fn();
+const mockUpdateOneProgramme = vi.fn();
+
+const env = {
+  TELEGRAM_BOT_TOKEN: "test-bot",
+  COMPLETED_SURVEY_LINK: "https://survey.example/done",
+  HOST_URL: "https://checkers.example",
+  CHECKERS_DB_SERVICE: {
+    findOneChecker: mockFindOneChecker,
+    updateOneChecker: mockUpdateOneChecker,
+    updateOneProgramme: mockUpdateOneProgramme,
+  },
+} as unknown as Env;
+
+const data = {
+  checkerId: "checker-001",
+  programmeId: "programme-001",
+  stats: { voteCount: 55, accuracy: 75, reportCount: 12 },
+};
+
+describe("handleProgrammeCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindOneChecker.mockResolvedValue({
+      success: true,
+      data: { _id: "checker-001", name: "Alice", telegramId: "123456" },
+    });
+    mockUpdateOneProgramme.mockResolvedValue({ success: true, modifiedCount: 1 });
+    mockUpdateOneChecker.mockResolvedValue({ success: true, modifiedCount: 1 });
+    sendMessageMock.mockResolvedValue(undefined);
+  });
+
+  it("marks the programme as completed without generating a certificate", async () => {
+    await handleProgrammeCompletion(env, data);
+
+    expect(generateCertificateMock).not.toHaveBeenCalled();
+    expect(mockUpdateOneProgramme).toHaveBeenCalledWith(
+      { _id: "programme-001" },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          status: "completed",
+          completedAt: expect.any(Date),
+          endDate: expect.any(Date),
+        }),
+      })
+    );
+    const programmeSet = mockUpdateOneProgramme.mock.calls[0][1].$set;
+    expect(programmeSet).not.toHaveProperty("certificateUrl");
+  });
+
+  it("nulls currentProgrammeId and marks the checker as completed", async () => {
+    await handleProgrammeCompletion(env, data);
+
+    expect(mockUpdateOneChecker).toHaveBeenCalledWith(
+      { _id: "checker-001" },
+      {
+        $set: {
+          currentProgrammeId: null,
+          hasCompletedProgramme: true,
+        },
+      }
+    );
+  });
+
+  it("sends a Telegram message with a web_app claim button", async () => {
+    await handleProgrammeCompletion(env, data);
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const [telegramId, , options] = sendMessageMock.mock.calls[0];
+    expect(telegramId).toBe("123456");
+    expect(options.reply_markup.inline_keyboard).toEqual([
+      [
+        {
+          text: "Claim your certificate",
+          web_app: { url: "https://checkers.example/graduation/claim" },
+        },
+      ],
+    ]);
+  });
+
+  it("short-circuits when checker lookup fails", async () => {
+    mockFindOneChecker.mockResolvedValue({ success: false, data: null });
+
+    await handleProgrammeCompletion(env, data);
+
+    expect(mockUpdateOneProgramme).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/workers/checkers-event-handler-service/src/constants.ts
+++ b/workers/checkers-event-handler-service/src/constants.ts
@@ -75,9 +75,15 @@ Your dedication has clearly paid off! 🎓
 
 We'd love to hear about your experience - please take a moment to fill out <a href='${params.surveyLink}'>our survey</a>
 
-To view your official completion certificate or to add it to your LinkedIn profile, just press the respective buttons below.
+To claim your official completion certificate, press the button below to confirm the name you'd like it issued to.
 
 Thank you for being part of the Checkers' Crew. We're so proud of you! 💪`,
+
+  certificateReady: (name: string) => `<b>📍 Your certificate is ready! 🎓</b>
+
+Hi ${name},
+
+Your CheckMate completion certificate has been issued. Use the buttons below to view it or add it to your LinkedIn profile.`,
 
   weeklyWelcome: (names: string) =>
     `<b>📍 Welcome to the Checkers' Crew! 👋</b>\n\nLet's welcome our new checkers!🎉\n\n${names}\n\nWe're so excited to have you join our fact-checking family. This group is your hub for connecting with fellow Checkers, sharing tips, and staying up to date with important updates.\n\nIf you ever feel unsure about anything, don't hesitate to reach out or ask in our Q&A channel. We're all here to support each other and improve our skills together 🤗\n\nLet's get started!`,

--- a/workers/checkers-event-handler-service/src/handlers/queue/onCertificateRequested.ts
+++ b/workers/checkers-event-handler-service/src/handlers/queue/onCertificateRequested.ts
@@ -1,0 +1,114 @@
+import { Bot } from "grammy";
+
+import { MESSAGES } from "../../constants";
+import { generateCertificate } from "../../helpers/generateCertificate";
+import { escapeHtml } from "../../helpers/html";
+import { generateLinkedInCredentialUrl } from "../../helpers/linkedInCredential";
+import type { CertificateRequestedData } from "../../types";
+
+/**
+ * Handle certificate.requested events.
+ *
+ * Fired when a graduated checker submits their preferred name via the miniapp.
+ * Generates the certificate, stores the URL, and sends a follow-up Telegram
+ * message with View Certificate / Add to LinkedIn buttons.
+ */
+export async function handleCertificateRequested(
+  env: Env,
+  data: CertificateRequestedData
+): Promise<void> {
+  const { checkerId, programmeId } = data;
+  console.log(
+    `Processing certificate.requested for checker ${checkerId}, programme ${programmeId}`
+  );
+
+  const [checkerResult, programmeResult] = await Promise.all([
+    env.CHECKERS_DB_SERVICE.findOneChecker({ _id: checkerId }),
+    env.CHECKERS_DB_SERVICE.findOneProgramme({ _id: programmeId }),
+  ]);
+
+  if (!checkerResult.success || !checkerResult.data) {
+    console.error(`Checker not found: ${checkerId}`);
+    return;
+  }
+  if (!programmeResult.success || !programmeResult.data) {
+    console.error(`Programme not found: ${programmeId}`);
+    return;
+  }
+
+  const checker = checkerResult.data;
+  const programme = programmeResult.data;
+
+  if (programme.certificateUrl) {
+    console.log(`Certificate already issued for programme ${programmeId}; skipping`);
+    return;
+  }
+
+  if (!programme.certificateName) {
+    console.error(`Programme ${programmeId} has no certificateName set`);
+    return;
+  }
+
+  const completionDate = programme.completedAt ?? new Date();
+
+  const certificateResult = await generateCertificate(env, {
+    userName: programme.certificateName,
+    programmeId,
+    targets: programme.targets,
+  });
+
+  if (!certificateResult.success || !certificateResult.url) {
+    console.error(`Failed to generate certificate: ${certificateResult.error}`);
+    return;
+  }
+
+  const [progUpdate, checkerUpdate] = await Promise.all([
+    env.CHECKERS_DB_SERVICE.updateOneProgramme(
+      { _id: programmeId },
+      { $set: { certificateUrl: certificateResult.url } }
+    ),
+    env.CHECKERS_DB_SERVICE.updateOneChecker(
+      { _id: checkerId },
+      { $set: { certificateUrl: certificateResult.url } }
+    ),
+  ]);
+  if (!progUpdate.success) {
+    console.error(
+      `Failed to persist certificateUrl on programme ${programmeId}: ${progUpdate.error ?? "unknown"}`
+    );
+  }
+  if (!checkerUpdate.success) {
+    console.error(
+      `Failed to persist certificateUrl on checker ${checkerId}: ${checkerUpdate.error ?? "unknown"}`
+    );
+  }
+
+  const linkedInCredentialUrl = generateLinkedInCredentialUrl({
+    certificateUrl: certificateResult.url,
+    programmeId,
+    completionDate,
+    linkedInOrgId: env.LINKEDIN_ORG_ID,
+  });
+
+  try {
+    const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
+    await bot.api.sendMessage(
+      checker.telegramId,
+      MESSAGES.certificateReady(escapeHtml(checker.name || "Checker")),
+      {
+        parse_mode: "HTML",
+        reply_markup: {
+          inline_keyboard: [
+            [
+              { text: "View your certificate!", url: certificateResult.url },
+              { text: "Add certificate to LinkedIn", url: linkedInCredentialUrl },
+            ],
+          ],
+        },
+      }
+    );
+    console.log(`Sent certificate ready message to checker ${checkerId}`);
+  } catch (err) {
+    console.error(`Failed to send certificate ready message: ${err}`);
+  }
+}

--- a/workers/checkers-event-handler-service/src/handlers/queue/onProgrammeCompletion.ts
+++ b/workers/checkers-event-handler-service/src/handlers/queue/onProgrammeCompletion.ts
@@ -1,17 +1,16 @@
 import { Bot } from "grammy";
 
 import { MESSAGES } from "../../constants";
-import { generateCertificate } from "../../helpers/generateCertificate";
-import { generateLinkedInCredentialUrl } from "../../helpers/linkedInCredential";
+import { escapeHtml } from "../../helpers/html";
 import type { ProgrammeCompletedData } from "../../types";
 
 /**
  * Handle programme.completed events
- * Performs all graduation side effects:
- * - Generate certificate and upload to R2
- * - Update programme status to "completed" with certificateUrl
- * - Update checker's currentProgrammeId to null
- * - Send congratulations message (TODO)
+ *
+ * Marks the checker as graduated and sends the congrats message with a
+ * "Claim your certificate" web_app button. Certificate generation happens
+ * later, in the certificate.requested handler, once the checker confirms
+ * the name they want on the cert.
  */
 export async function handleProgrammeCompletion(
   env: Env,
@@ -21,36 +20,13 @@ export async function handleProgrammeCompletion(
   const completionDate = new Date();
   console.log(`Processing programme.completed for checker ${checkerId}, programme ${programmeId}`);
 
-  // 1. Fetch checker data for certificate
   const checkerResult = await env.CHECKERS_DB_SERVICE.findOneChecker({ _id: checkerId });
   if (!checkerResult.success || !checkerResult.data) {
     console.error(`Checker not found: ${checkerId}`);
     return;
   }
-
-  // 2. Fetch programme data for targets
-  const programmeResult = await env.CHECKERS_DB_SERVICE.findOneProgramme({ _id: programmeId });
-  if (!programmeResult.success || !programmeResult.data) {
-    console.error(`Programme not found: ${programmeId}`);
-    return;
-  }
-
   const checker = checkerResult.data;
-  const programme = programmeResult.data;
 
-  // 3. Generate certificate
-  const certificateResult = await generateCertificate(env, {
-    userName: checker.name || "Checker",
-    programmeId,
-    targets: programme.targets,
-  });
-
-  if (!certificateResult.success) {
-    console.error(`Failed to generate certificate: ${certificateResult.error}`);
-    // Continue with graduation even if certificate fails
-  }
-
-  // 4. Update programme status with certificateUrl in single DB call
   const programmeUpdate = await env.CHECKERS_DB_SERVICE.updateOneProgramme(
     { _id: programmeId },
     {
@@ -58,7 +34,6 @@ export async function handleProgrammeCompletion(
         status: "completed",
         completedAt: completionDate,
         endDate: completionDate,
-        ...(certificateResult.url && { certificateUrl: certificateResult.url }),
       },
     }
   );
@@ -68,14 +43,12 @@ export async function handleProgrammeCompletion(
     return;
   }
 
-  // 5. Update checker
   const checkerUpdate = await env.CHECKERS_DB_SERVICE.updateOneChecker(
     { _id: checkerId },
     {
       $set: {
         currentProgrammeId: null,
         hasCompletedProgramme: true,
-        ...(certificateResult.url && { certificateUrl: certificateResult.url }),
       },
     }
   );
@@ -87,53 +60,33 @@ export async function handleProgrammeCompletion(
 
   console.log(`Checker ${checkerId} graduated from programme ${programmeId}`);
 
-  // Generate LinkedIn credential URL only if certificate was successfully created
-  let linkedInCredentialUrl: string | null = null;
-  if (certificateResult.url) {
-    console.log(`Certificate URL: ${certificateResult.url}`);
-    linkedInCredentialUrl = generateLinkedInCredentialUrl({
-      certificateUrl: certificateResult.url,
-      programmeId,
-      completionDate,
-      linkedInOrgId: env.LINKEDIN_ORG_ID,
+  try {
+    const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
+    const message = MESSAGES.graduation({
+      name: escapeHtml(checker.name || "Checker"),
+      numMessages: data.stats.voteCount,
+      accuracy: data.stats.accuracy,
+      numReferred: 0,
+      numReported: data.stats.reportCount,
+      surveyLink: env.COMPLETED_SURVEY_LINK,
     });
-    console.log(`LinkedIn credential URL: ${linkedInCredentialUrl}`);
-  }
 
-  // 6. Send congratulations message via Telegram
-  if (certificateResult.url && linkedInCredentialUrl) {
-    try {
-      const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
-      const message = MESSAGES.graduation({
-        name: checker.name || "Checker",
-        numMessages: data.stats.voteCount,
-        accuracy: data.stats.accuracy,
-        numReferred: 0, // Referrals not implemented yet
-        numReported: data.stats.reportCount,
-        surveyLink: env.COMPLETED_SURVEY_LINK,
-      });
-
-      await bot.api.sendMessage(checker.telegramId, message, {
-        parse_mode: "HTML",
-        reply_markup: {
-          inline_keyboard: [
-            [
-              {
-                text: "View your certificate!",
-                url: certificateResult.url,
-              },
-              {
-                text: "Add certificate to LinkedIn",
-                url: linkedInCredentialUrl,
-              },
-            ],
+    await bot.api.sendMessage(checker.telegramId, message, {
+      parse_mode: "HTML",
+      reply_markup: {
+        inline_keyboard: [
+          [
+            {
+              text: "Claim your certificate",
+              web_app: { url: `${env.HOST_URL}/graduation/claim` },
+            },
           ],
-        },
-      });
+        ],
+      },
+    });
 
-      console.log(`Sent graduation message to checker ${checkerId}`);
-    } catch (err) {
-      console.error(`Failed to send graduation message: ${err}`);
-    }
+    console.log(`Sent graduation message to checker ${checkerId}`);
+  } catch (err) {
+    console.error(`Failed to send graduation message: ${err}`);
   }
 }

--- a/workers/checkers-event-handler-service/src/helpers/generateCertificate.ts
+++ b/workers/checkers-event-handler-service/src/helpers/generateCertificate.ts
@@ -1,4 +1,5 @@
 import { CERTIFICATE_TEMPLATE } from "./certificateTemplate";
+import { escapeHtml } from "./html";
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 1000;
@@ -68,9 +69,9 @@ export async function generateCertificate(
       year: "numeric",
     });
 
-    // Replace template placeholders
+    // Replace template placeholders (escape name — it's user input)
     let html = CERTIFICATE_TEMPLATE;
-    html = html.replace(/{{userName}}/g, userName);
+    html = html.replace(/{{userName}}/g, escapeHtml(userName));
     html = html.replace("{{issuanceDate}}", issuanceDate);
     html = html.replace("{{certificateId}}", programmeId);
     html = html.replace("{{numVotesTarget}}", targets.votes.toFixed(0));

--- a/workers/checkers-event-handler-service/src/helpers/html.ts
+++ b/workers/checkers-event-handler-service/src/helpers/html.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/workers/checkers-event-handler-service/src/index.ts
+++ b/workers/checkers-event-handler-service/src/index.ts
@@ -2,6 +2,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import { Bot } from "grammy";
 
 import { handleAssessmentComplete } from "./handlers/queue/onAssessmentComplete";
+import { handleCertificateRequested } from "./handlers/queue/onCertificateRequested";
 import { handlePrimaryCategoryChanged } from "./handlers/queue/onPrimaryCategoryChanged";
 import { handleProgrammeCompletion } from "./handlers/queue/onProgrammeCompletion";
 import { handleVoteScoreChange } from "./handlers/queue/onVoteScoreChange";
@@ -12,6 +13,7 @@ import { runProgrammeChecks } from "./handlers/scheduled/programme";
 import { runWeeklyWelcomeMessage } from "./handlers/scheduled/welcomeMessage";
 import type {
   AssessmentCompleteData,
+  CertificateRequestedData,
   CheckersEvent,
   PrimaryCategoryChangedData,
   ProgrammeCompletedData,
@@ -63,6 +65,10 @@ export default class extends WorkerEntrypoint<Env> {
 
           case "programme.completed":
             await handleProgrammeCompletion(this.env, event.data as ProgrammeCompletedData);
+            break;
+
+          case "certificate.requested":
+            await handleCertificateRequested(this.env, event.data as CertificateRequestedData);
             break;
 
           case "vote.scoreChanged":

--- a/workers/checkers-event-handler-service/src/types.ts
+++ b/workers/checkers-event-handler-service/src/types.ts
@@ -84,7 +84,13 @@ export interface ProgrammeAPI {
   hasReceivedExtension: boolean;
   hasReceivedLowAccuracyWarning: boolean;
   certificateUrl: string | null;
+  certificateName: string | null;
   completedAt: Date | null;
+}
+
+export interface CertificateRequestedData {
+  checkerId: string;
+  programmeId: string;
 }
 
 // Service binding interfaces

--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -370,7 +370,11 @@ By the end, you'll be ready to make your first check and join CheckMate in actio
       return;
     }
 
-    const phoneNumber = ctx.message.contact.phone_number;
+    const phoneNumber = normalizePhoneNumber(ctx.message.contact.phone_number);
+    if (!phoneNumber) {
+      await ctx.reply("The phone number received is invalid. Please enter your number manually.");
+      return;
+    }
     await processPhoneNumber(ctx, env, telegramId, phoneNumber, user);
   });
 

--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -772,6 +772,7 @@ async function sendCompletionPrompt(ctx: Context, env: Env, telegramId: string):
         hasReceivedExtension: false,
         hasReceivedLowAccuracyWarning: false,
         certificateUrl: null,
+        certificateName: null,
         completedAt: null,
       });
 

--- a/workers/checkers-webhook-service/src/types.ts
+++ b/workers/checkers-webhook-service/src/types.ts
@@ -181,6 +181,7 @@ export interface ProgrammeAPI {
   hasReceivedExtension: boolean;
   hasReceivedLowAccuracyWarning: boolean;
   certificateUrl: string | null;
+  certificateName: string | null;
   completedAt: Date | null;
 }
 


### PR DESCRIPTION
## Summary

Implements [#153](https://github.com/checkmate-sg/checkers-service/issues/153) — graduated checkers can now confirm/edit the name that appears on their completion certificate, instead of reusing the (often aliased) onboarding name.

Graduation is now a two-step flow:

1. **`programme.completed`** — when all targets are met, the checker is marked graduated and gets a Telegram congrats message with a single *"Claim your certificate"* `web_app` button pointing at `/graduation/claim`. No cert is generated yet.
2. **Claim miniapp** (`/graduation/claim`) — shows a form pre-filled with `checker.name` and the label *"This name will appear on your certificate."*
3. **`POST /api/checkers/[id]/certificate`** — stores `certificateName` on the programme and emits a new `certificate.requested` queue event.
4. **`certificate.requested`** — generates the cert using `programme.certificateName`, stores the URL on programme + checker, and sends a follow-up Telegram message with View Certificate / LinkedIn buttons.

If a checker never claims, the programme stays `completed` with `certificateUrl: null` — no nags (per scope decision with @sarge1989).

### Scope decisions (confirmed before implementation)
- Name is immutable once issued — the claim page shows the existing cert in that case.
- Existing graduates (already issued with alias) are **out of scope** — no backfill.
- No reminders for unclaimed certs. We can add later if uptake is poor.

### Security / hardening
- New `escapeHtml` helper (`workers/.../helpers/html.ts`) applied to the name before it hits the cert template **and** Telegram HTML-parsed messages (`graduation`, `certificateReady`).
- `POST /certificate` authorizes via `session.user.id === checkerId`, validates name (1-100 chars, strips control chars), and uses a CAS-style filter `{ _id, certificateUrl: null }` on the update — returns **409 Conflict** on a race instead of 500.
- `certificate.requested` handler is idempotent: skips generation if `programme.certificateUrl` is already set.
- DB update failures on the second handler are logged so they surface in monitoring.

### Bundled fix
`bot.ts` contact-share handler now routes through `normalizePhoneNumber`, so checkers who tap *"Share phone number"* don't end up with a `+` prefix in their `whatsappId`. Separate commit.

## Test plan

- [x] `pnpm test` — 136/136 passing (3 new suites: `onProgrammeCompletion`, `onCertificateRequested`, `certificateRoute`)
- [ ] Local dev: trigger graduation for a test checker → confirm Telegram message received with claim button
- [ ] Tap claim button → confirm `/graduation/claim` opens with name pre-filled
- [ ] Submit a different name → confirm follow-up Telegram message with View / LinkedIn buttons, and cert HTML shows submitted name (verified locally via `wrangler r2 object get checkmate-certificates/<programmeId>.html --local`)
- [ ] Double-submit → 409
- [ ] Return to `/graduation/claim` after claim → shows the existing cert link, not the form
- [ ] Checker with no completed programme visiting `/graduation/claim` → redirects to `/dashboard`
- [ ] Onboard fresh checker via *Share phone number* button → confirm `whatsappId` stored without `+`

🤖 Generated with [Claude Code](https://claude.com/claude-code)