### PR TITLE
fix: stub whatsapp checkUser in local dev

### DIFF
--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -2,6 +2,7 @@ import { Bot, Context, InlineKeyboard, Keyboard } from "grammy";
 
 import { getParameters } from "@/shared/helpers/parameters";
 
+import { checkWhatsAppUser } from "./checkWhatsAppUser";
 import {
   createNewChecker,
   normalizePhoneNumber,
@@ -170,8 +171,7 @@ By the end, you'll be ready to make your first check and join CheckMate in actio
         await ctx.reply(
           `Thank you for completing the quiz!💪🎉 We hope you found it useful.\n\n${progressBar(3)}`
         );
-        const checkResult = await env.WHATSAPP_CHECKER_HANDLER_SERVICE.checkUser(user.whatsappId);
-        // const checkResult = {exists: null}
+        const checkResult = await checkWhatsAppUser(env, user.whatsappId);
         if (checkResult.exists) {
           await sendTGGroupPrompt(ctx, env, telegramId, true);
         } else {
@@ -208,7 +208,7 @@ By the end, you'll be ready to make your first check and join CheckMate in actio
     }
 
     try {
-      const checkResult = await env.WHATSAPP_CHECKER_HANDLER_SERVICE.checkUser(user.whatsappId);
+      const checkResult = await checkWhatsAppUser(env, user.whatsappId);
       if (checkResult.exists) {
         await sendTGGroupPrompt(ctx, env, telegramId, true);
       } else {

--- a/workers/checkers-webhook-service/src/checkWhatsAppUser.ts
+++ b/workers/checkers-webhook-service/src/checkWhatsAppUser.ts
@@ -1,0 +1,17 @@
+/**
+ * Wraps env.WHATSAPP_CHECKER_HANDLER_SERVICE.checkUser so local dev doesn't
+ * crash when the whatsapp-checker-event-handler worker isn't running.
+ * In local, treat every user as already existing in the WhatsApp service.
+ */
+export async function checkWhatsAppUser(
+  env: Env,
+  whatsappId: string | null
+): Promise<{ exists: boolean }> {
+  if (!whatsappId) {
+    return { exists: false };
+  }
+  if (env.ENVIRONMENT === "local") {
+    return { exists: true };
+  }
+  return env.WHATSAPP_CHECKER_HANDLER_SERVICE.checkUser(whatsappId);
+}


### PR DESCRIPTION
## Summary

The webhook service errored during \`QUIZ_COMPLETED\` and \`WA_SERVICE_COMPLETED\` callbacks in local dev because no \`whatsapp-checker-event-handler\` worker session exists to proxy to:

\`\`\`
✘ [ERROR] Error in QUIZ_COMPLETED callback: Error: Cannot access "checkUser" as
we couldn't find a local dev session for the "default" entrypoint of service
"whatsapp-checker-event-handler" to proxy to.
\`\`\`

Adds a small \`checkWhatsAppUser(env, whatsappId)\` wrapper that short-circuits to \`{ exists: true }\` when \`env.ENVIRONMENT === "local"\`, so the Telegram onboarding flow can be tested end-to-end locally. Both existing callsites in \`bot.ts\` are routed through the wrapper.

\`ENVIRONMENT === "local"\` is only set in the top-level wrangler config — staging/production use their own values, so there's no risk of the stub leaking into deployed environments.

## Test plan

- [x] \`pnpm test\` — 118/118 passing (no behavior change in prod paths)
- [ ] \`pnpm dev:workers\` + \`pnpm dev\` locally → complete quiz as test checker → callback no longer errors, onboarding continues to WA service / TG group prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)