### PR TITLE
v1.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ Located in `src/lib/helpers/voteAssessment/`. Determines consensus based on:
 
 - Node.js (v18 or higher)
 - pnpm (v10 or higher)
-- MongoDB Atlas account
-- Telegram Bot Token
 - Git
+- [MongoDB Compass](https://www.mongodb.com/try/download/compass) — GUI client for inspecting the dev database
+- (Optional) Your own Telegram bot via BotFather if you want to test bot UX end-to-end. Not needed for backend/webhook work — you can hit endpoints directly with curl.
 
 ### Quick Start
 
@@ -156,20 +156,31 @@ cd checkers-service
 
 # Install dependencies (pnpm monorepo - installs all workers too)
 pnpm install
-
-# Copy environment variables template
-cp .env.example .env.development.local
-
-# Configure your .env.development.local with:
-# - MongoDB connection string
-# - Telegram bot token
-# - NextAuth configuration
-
-# Copy worker environment variables
-cp workers/checkers-db-service/.dev.vars.example workers/checkers-db-service/.dev.vars
-cp workers/checkers-webhook-service/.dev.vars.example workers/checkers-webhook-service/.dev.vars
-# ... repeat for other workers as needed
 ```
+
+#### Environment files
+
+The project uses several env files, none of which are checked in:
+
+| File                                                | Purpose                            |
+| --------------------------------------------------- | ---------------------------------- |
+| `.env.development.local`                            | Next.js app config (incl. MongoDB) |
+| `.dev.vars` (root)                                  | Local dev shared vars              |
+| `workers/checkers-db-service/.dev.vars`             | DB worker secrets                  |
+| `workers/checkers-webhook-service/.dev.vars`        | Telegram bot token, API key, etc.  |
+| `workers/checkers-event-handler-service/.dev.vars`  | Queue + cron worker secrets        |
+| `workers/checkers-reminder-alarm-service/.dev.vars` | Alarm worker secrets               |
+
+These contain real secrets and a connection string to a shared dev MongoDB. **Request the bundle from the project lead** rather than provisioning your own — it ensures you connect to the same dev data as everyone else. Unzip into the repo root and the structure is preserved.
+
+#### Connect MongoDB Compass
+
+1. Open Compass.
+2. Copy `MONGODB_CONNECTION_STRING` from `.env.development.local`.
+3. Paste into the connection field and connect.
+4. Key collections: `checkers`, `polls`, `votes`, `programmes`.
+
+The dev DB is **shared** — be careful when modifying records, and prefer creating new test rows over editing existing ones.
 
 ### Running Locally
 
@@ -182,6 +193,23 @@ pnpm dev
 
 # The app will be available at http://localhost:3002
 ```
+
+#### Smoke test
+
+Send a test poll to the webhook to confirm fan-out works end-to-end:
+
+```bash
+curl -X POST http://localhost:9083/polls/webhook \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY from workers/checkers-webhook-service/.dev.vars>" \
+  -d '{
+    "checkId": "test_'$(date +%s)'",
+    "text": "Test message",
+    "isReport": false
+  }'
+```
+
+In Compass, a new row should appear in `polls`, plus one row per active checker in `votes` (with `votedTimestamp: null` until the checker votes).
 
 ### Worker Ports
 

--- a/workers/checkers-webhook-service/src/bot.ts
+++ b/workers/checkers-webhook-service/src/bot.ts
@@ -302,7 +302,8 @@ By the end, you'll be ready to make your first check and join CheckMate in actio
 
   bot.callbackQuery("REQUEST_NUMBER", async ctx => {
     await safeAnswerCallbackQuery(ctx);
-    await sendNumberPrompt(ctx);
+    const telegramId = ctx.from!.id.toString();
+    await sendNumberPrompt(ctx, env, telegramId);
   });
 
   bot.callbackQuery("SEND_OTP", async ctx => {
@@ -314,7 +315,7 @@ By the end, you'll be ready to make your first check and join CheckMate in actio
 
     if (!user || !user.whatsappId) {
       await ctx.reply("Please enter your phone number first.");
-      await sendNumberPrompt(ctx);
+      await sendNumberPrompt(ctx, env, telegramId);
       return;
     }
 
@@ -426,7 +427,7 @@ async function resumeOnboarding(ctx: Context, env: Env, user: CheckerAPI): Promi
       await sendNamePrompt(ctx);
       break;
     case "number":
-      await sendNumberPrompt(ctx);
+      await sendNumberPrompt(ctx, env, telegramId);
       break;
     case "otpSent":
     case "verify":
@@ -434,7 +435,7 @@ async function resumeOnboarding(ctx: Context, env: Env, user: CheckerAPI): Promi
       if (user.whatsappId) {
         await sendOTPPrompt(ctx, env, telegramId, user.whatsappId, user._id!);
       } else {
-        await sendNumberPrompt(ctx);
+        await sendNumberPrompt(ctx, env, telegramId);
       }
       break;
     case "quiz":
@@ -468,13 +469,12 @@ async function handleNameInput(
     {
       $set: {
         name: text.trim(),
-        onboardingStatus: "number",
         updatedAt: new Date(),
       },
     }
   );
 
-  await sendNumberPrompt(ctx);
+  await sendNumberPrompt(ctx, env, telegramId);
 }
 
 async function handlePhoneInput(
@@ -526,7 +526,7 @@ async function handleOTPInput(
 
   if (!whatsappId) {
     await ctx.reply("Please enter your phone number first.");
-    await sendNumberPrompt(ctx);
+    await sendNumberPrompt(ctx, env, telegramId);
     return;
   }
 
@@ -574,7 +574,12 @@ async function sendNamePrompt(ctx: Context): Promise<void> {
   });
 }
 
-async function sendNumberPrompt(ctx: Context): Promise<void> {
+async function sendNumberPrompt(ctx: Context, env: Env, telegramId: string): Promise<void> {
+  await env.CHECKERS_DB_SERVICE.updateOneChecker(
+    { telegramId },
+    { $set: { onboardingStatus: "number", updatedAt: new Date() } }
+  );
+
   const keyboard = new Keyboard().requestContact("📱 Share Phone Number").resized().oneTime();
 
   await ctx.reply(


### PR DESCRIPTION
## Summary

Release v1.0.12 — onboarding state-machine fix and local-dev docs refresh.

### Fixes
- **Reset `onboardingStatus` when re-prompting for phone number (#158)**: tapping "Re-enter phone number" (and a few related paths) showed the phone-prompt UI but left `onboardingStatus` at `"verify"`, so the next number a checker typed was routed to the OTP handler and rejected with "The OTP you provided doesn't match our records." Reported by a real checker who couldn't amend a wrongly-keyed number. `sendNumberPrompt` now owns the `"number"` state write — mirroring how `sendOTPPrompt` and `sendVerificationPrompt` own theirs — so all six call sites (REQUEST_NUMBER, SEND_OTP fallback, both `resumeOnboarding` branches, `handleNameInput`, `handleOTPInput` recovery) are correct in one place. Also closes three latent variants of the same bug.

### Docs
- **Local-dev setup rework (#158)**: replaces "provision your own Atlas + bot + copy `.env.example`" with "request the dev bundle from the project lead" so new contributors connect to the shared dev MongoDB. Adds a Compass walkthrough and a smoke-test curl for first-run verification.

## Test plan

- [x] Unit tests pass (136/136)
- [ ] Reach `verify` state in Telegram onboarding → tap "Re-enter phone number" → enter a new number → confirm a fresh OTP is sent (not "OTP doesn't match")
- [ ] Verify in MongoDB Compass that `onboardingStatus` flips to `"number"` after tapping "Re-enter phone number"
- [ ] Regression: fresh checker → `/onboard` → name → number → OTP → quiz works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)