### PR TITLE
chore: add synthetic checker seed script for staging distribution testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ dist-ssr
 tsconfig.tsbuildinfo
 
 # Local scripts (test data, utilities)
-scripts/
+scripts/*
+!scripts/seed-synthetic-checkers.js
 parameters/

--- a/README.md
+++ b/README.md
@@ -397,6 +397,19 @@ pnpm deploy     # Deploy to Cloudflare
 
 Run `pnpm test` to execute unit tests.
 
+### Testing vote distribution in staging
+
+Staging has too few real checkers to exercise the distribution engine. Use `scripts/seed-synthetic-checkers.js` to plant marked (`isSynthetic: true`) checker documents with varied budgets: 35+ bulk checkers so the out-of-window top-30 selection is observable, deliberately invalid Telegram IDs to exercise rollback, an at-cap checker that must never be assigned, and (optionally) checkers pointing at your own Telegram ID for end-to-end delivery.
+
+```bash
+# Reads MONGODB_URI from .env.staging at the repo root
+node scripts/seed-synthetic-checkers.js seed --real-telegram-id <your-telegram-id>
+node scripts/seed-synthetic-checkers.js deactivate   # exclude from all pipelines, keep docs
+node scripts/seed-synthetic-checkers.js cleanup      # remove the checkers and their votes
+```
+
+Then fire test polls at the staging webhook (see [Testing the Poll Webhook](#testing-the-poll-webhook)) and verify via the response tallies, `wrangler tail`, and the database. Mind two staging quirks: the fast inactivity parameters (`INACTIVITY_DEACTIVATION_DAYS` ≈ 30 minutes) deactivate seeded checkers holding uncast votes at the daily 8:11 PM SGT sweep, and casting votes can assess a poll early (removing it from redistribution) because consensus thresholds scale with the assignment count.
+
 ## Known Issues / TODOs
 
 - Dashboard messages sent uses checkers num referred, may not be the actual number of WhatsApp messages sent

--- a/scripts/seed-synthetic-checkers.js
+++ b/scripts/seed-synthetic-checkers.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+/**
+ * Seed (and clean up) synthetic checkers for testing vote distribution in staging.
+ *
+ * Every document this script creates carries `isSynthetic: true` and a
+ * `synthetic-` name prefix so it can be removed or deactivated in one command.
+ *
+ * Usage:
+ *   MONGODB_CONNECTION_STRING="<staging uri>" node scripts/seed-synthetic-checkers.js seed [--real-telegram-id <id>] [--bulk <n>]
+ *   MONGODB_CONNECTION_STRING="<staging uri>" node scripts/seed-synthetic-checkers.js deactivate
+ *   MONGODB_CONNECTION_STRING="<staging uri>" node scripts/seed-synthetic-checkers.js cleanup
+ *
+ * Groups seeded:
+ *   real    - deliver to a real Telegram account (only if --real-telegram-id given); tests the happy path end-to-end
+ *   poison  - invalid telegram IDs; the send step fails, exercising rollback
+ *   bulk    - N checkers (default 35) with varied budgets; makes the top-30 ranking observable.
+ *             Their telegram IDs are fake too, so their assignments also roll back by design:
+ *             selection behaviour is verified from the webhook response tallies/contexts, not
+ *             from surviving votes, and their budget counters stay at the seeded values.
+ *   at-cap  - dailyAssignmentCount == targetDailyVotes; must never be selected
+ */
+
+import { MongoClient } from "mongodb";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const DB_NAME = "checkmate-checkers-app";
+
+// Values with & or = break shell sourcing, so read .env.staging directly
+// instead of relying on exported vars.
+function loadEnvFile() {
+  const path = join(dirname(fileURLToPath(import.meta.url)), "..", ".env.staging");
+  try {
+    return Object.fromEntries(
+      readFileSync(path, "utf-8")
+        .split("\n")
+        .filter(line => line.includes("=") && !line.trimStart().startsWith("#"))
+        .map(line => {
+          const [key, ...rest] = line.split("=");
+          return [
+            key.trim(),
+            rest
+              .join("=")
+              .trim()
+              .replace(/^["']|["']$/g, ""),
+          ];
+        })
+    );
+  } catch {
+    return {};
+  }
+}
+
+const envFile = loadEnvFile();
+const uri =
+  process.env.MONGODB_CONNECTION_STRING ??
+  process.env.MONGODB_URI ??
+  envFile.MONGODB_CONNECTION_STRING ??
+  envFile.MONGODB_URI;
+if (!uri) {
+  console.error(
+    "No MongoDB URI found: set MONGODB_CONNECTION_STRING / MONGODB_URI, or put MONGODB_URI in .env.staging."
+  );
+  process.exit(1);
+}
+
+// This script inserts and deletes checker documents — never point it at prod.
+let uriHost = "";
+try {
+  uriHost = new URL(uri).host;
+} catch {}
+if (!/staging|local/i.test(uriHost) && !process.argv.includes("--force")) {
+  console.error(
+    `Host "${uriHost}" does not look like a staging or local cluster. ` +
+      "Pass --force if you are certain this is not production."
+  );
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const command = args[0];
+if (!["seed", "deactivate", "cleanup"].includes(command)) {
+  console.error(
+    "Usage: node scripts/seed-synthetic-checkers.js <seed|deactivate|cleanup> [options]"
+  );
+  process.exit(1);
+}
+
+function getFlag(name) {
+  const i = args.indexOf(name);
+  if (i === -1) return undefined;
+  const value = args[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`Flag ${name} requires a value.`);
+    process.exit(1);
+  }
+  return value;
+}
+
+const realTelegramId = getFlag("--real-telegram-id");
+const bulkCount = parseInt(getFlag("--bulk") ?? "35", 10);
+if (!Number.isInteger(bulkCount) || bulkCount < 0) {
+  console.error(`Invalid --bulk value: ${getFlag("--bulk")}`);
+  process.exit(1);
+}
+
+function baseChecker(name, telegramId, overrides = {}) {
+  const now = new Date();
+  return {
+    name: `synthetic-${name}`,
+    telegramId,
+    telegramUsername: null,
+    whatsappId: null,
+    singpassId: null,
+    isActive: true,
+    isOnboardingComplete: true,
+    onboardingTime: now,
+    isQuizComplete: true,
+    quizScore: null,
+    onboardingStatus: "completed",
+    hasReceivedExtension: false,
+    hasCompletedProgramme: false,
+    certificateUrl: null,
+    lastActivatedDate: now,
+    offboardingTime: null,
+    lastInactivityWarningSent: null,
+    numVoted: 0,
+    lastVotedTimestamp: now,
+    getNameMessageId: null,
+    dailyAssignmentCount: 0,
+    currentProgrammeId: null,
+    targetDailyVotes: 10,
+    isSynthetic: true,
+    ...overrides,
+  };
+}
+
+function buildCheckers() {
+  const checkers = [];
+
+  if (realTelegramId) {
+    // Real deliveries to your own Telegram account: one small budget, one
+    // default, one receive-all sentinel (100).
+    checkers.push(baseChecker("real-low", realTelegramId, { targetDailyVotes: 5 }));
+    checkers.push(baseChecker("real-default", realTelegramId));
+    checkers.push(baseChecker("real-all", realTelegramId, { targetDailyVotes: 100 }));
+  }
+
+  // Telegram IDs that no chat answers to -> sendMessage fails -> rollback path.
+  checkers.push(baseChecker("poison-1", "999999999991"));
+  checkers.push(baseChecker("poison-2", "999999999992"));
+
+  for (let i = 0; i < bulkCount; i++) {
+    const target = [5, 10, 20, 30, 50][i % 5];
+    const overrides = {
+      // Spread of remaining budget so the top-30 sort has something to rank.
+      targetDailyVotes: target,
+      dailyAssignmentCount: i % 4 === 0 ? Math.min(3, target - 1) : 0,
+    };
+    const checker = baseChecker(
+      `bulk-${String(i + 1).padStart(3, "0")}`,
+      `888800000${i}`,
+      overrides
+    );
+    // A couple of legacy-shaped docs with no targetDailyVotes field, to hit
+    // the pipelines' $ifNull default of 10. Must be removed after the base
+    // defaults are merged in, or the base value survives.
+    if (i % 10 === 9) delete checker.targetDailyVotes;
+    checkers.push(checker);
+  }
+
+  // Already at cap: must never be assigned.
+  checkers.push(
+    baseChecker("at-cap", "8889999999", { targetDailyVotes: 5, dailyAssignmentCount: 5 })
+  );
+
+  return checkers;
+}
+
+const client = new MongoClient(uri);
+try {
+  await client.connect();
+  const db = client.db(DB_NAME);
+  console.log(`Connected to ${uriHost || "(unparseable host)"}, db "${DB_NAME}"`);
+
+  if (command === "seed") {
+    const existing = await db.collection("checkers").countDocuments({ isSynthetic: true });
+    if (existing > 0) {
+      console.error(
+        `${existing} synthetic checkers already exist. Run cleanup first to avoid duplicates.`
+      );
+      process.exit(1);
+    }
+    const checkers = buildCheckers();
+    const result = await db.collection("checkers").insertMany(checkers);
+    console.log(`Inserted ${result.insertedCount} synthetic checkers:`);
+    for (const c of checkers) {
+      console.log(
+        `  ${c.name}  telegramId=${c.telegramId}  target=${c.targetDailyVotes ?? "(unset -> 10)"}  used=${c.dailyAssignmentCount}`
+      );
+    }
+    if (!realTelegramId) {
+      console.log("\nNote: no --real-telegram-id given, so no happy-path checkers were seeded.");
+    }
+  } else if (command === "deactivate") {
+    const result = await db
+      .collection("checkers")
+      .updateMany({ isSynthetic: true }, { $set: { isActive: false } });
+    console.log(
+      `Deactivated ${result.modifiedCount} synthetic checkers (docs kept, excluded from all pipelines).`
+    );
+  } else if (command === "cleanup") {
+    const synthetic = await db
+      .collection("checkers")
+      .find({ isSynthetic: true }, { projection: { _id: 1 } })
+      .toArray();
+    const ids = synthetic.map(c => c._id);
+    const votes = await db.collection("votes").deleteMany({ checkerId: { $in: ids } });
+    const checkers = await db.collection("checkers").deleteMany({ isSynthetic: true });
+    console.log(
+      `Deleted ${checkers.deletedCount} synthetic checkers and ${votes.deletedCount} of their votes.`
+    );
+  }
+} finally {
+  await client.close();
+}


### PR DESCRIPTION
## Summary

Staging has too few real checkers to exercise the vote distribution engine, so this adds `scripts/seed-synthetic-checkers.js`, which plants marked (`isSynthetic: true`) checker documents shaped for each distribution scenario:

- **35+ bulk checkers** with a spread of `targetDailyVotes`/`dailyAssignmentCount` (including legacy-shaped docs missing `targetDailyVotes`, to hit the `$ifNull` default) — makes the out-of-window top-30 ranking observable, which is indistinguishable from full distribution with fewer than 30 eligible checkers
- **Poison checkers** with invalid Telegram IDs — deterministically exercises the state-machine rollback path
- **An at-cap checker** (`dailyAssignmentCount == targetDailyVotes`) — must never be selected
- **Optional real checkers** pointing at your own Telegram ID (`--real-telegram-id`) — end-to-end delivery and vote-flow testing

Also includes `deactivate` (flip `isActive` off, keep docs) and `cleanup` (remove checkers + their votes) commands, a production-host guard (refuses hosts not matching staging/local unless `--force`), and a README section documenting the workflow and the staging quirks that affect it (fast inactivity deactivation, early poll assessment with small assignment pools).

Note: `.gitignore` previously ignored `scripts/` wholesale; changed to `scripts/*` + an exception so this file can be tracked (directory-level ignores can't be negated).

## Test plan

- [x] Used for the full staging test campaign of the vote distribution feature (2026-07-18): initial distribution, budget caps, rollback, canary split, in/out-of-window branches, top-30 ranking, redistribution cron dedup and capacity sort
- [x] Guard smoke tests: invalid `--bulk`, flag-without-value, duplicate seed, non-staging host all exit 1 without writes
- [x] Unit tests pass (137/137)

🤖 Generated with [Claude Code](https://claude.com/claude-code)