### PR TITLE
v1.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,5 +420,6 @@ Then fire test polls at the staging webhook (see [Testing the Poll Webhook](#tes
 
 **Vote Distribution Engine** (see section above):
 
-- `targetDailyVotes` is currently enforced only as a cap, not a target — checkers who fall well short of their chosen number aren't topped up. Reframing the distribution to honour it as a target (and adding a "receive every check" cohort) is planned work; see PR #162 discussion.
+- `targetDailyVotes` is currently enforced only as a cap, not a target — checkers who fall well short of their chosen number aren't topped up. Reframing the distribution to honour it as a target is planned work; see PR #162 discussion. (The "receive every check" sentinel of 100 _is_ honoured by initial distribution: those checkers are always included, even in the out-of-window top-N phase.)
+- Redistribution top-ups rank candidates by remaining capacity but do not hard-filter on it, so when a poll still needs votes and every under-target checker has already seen it, checkers can be assigned past their daily target. Deliberate trade-off (reaching 30 votes wins); revisit in the target-as-top-up rework.
 - `StateRunner` is a single shared instance on `BasePollDistributor` whose `executed` array is mutated while all checkers' assignments run concurrently (`Promise.allSettled`). Under parallel load the rollback bookkeeping can replay or skip the wrong states. A `StateRunner` should be instantiated per assignment.

--- a/scripts/seed-synthetic-checkers.js
+++ b/scripts/seed-synthetic-checkers.js
@@ -18,6 +18,8 @@
  *             Their telegram IDs are fake too, so their assignments also roll back by design:
  *             selection behaviour is verified from the webhook response tallies/contexts, not
  *             from surviving votes, and their budget counters stay at the seeded values.
+ *   receive-all - targetDailyVotes 100 (the sentinel), fake IDs; must be included in
+ *             every initial distribution, including the out-of-window top-N phase
  *   at-cap  - dailyAssignmentCount == targetDailyVotes; must never be selected
  */
 
@@ -170,6 +172,11 @@ function buildCheckers() {
     if (i % 10 === 9) delete checker.targetDailyVotes;
     checkers.push(checker);
   }
+
+  // Receive-all sentinel (fake IDs): must be included in every initial
+  // distribution, including the out-of-window top-N phase.
+  checkers.push(baseChecker("receive-all-1", "8888777001", { targetDailyVotes: 100 }));
+  checkers.push(baseChecker("receive-all-2", "8888777002", { targetDailyVotes: 100 }));
 
   // Already at cap: must never be assigned.
   checkers.push(

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -6,5 +6,7 @@ export const MIN_TARGET_DAILY_VOTES = 5;
 // Upper bound for a checker's daily target. Doubles as the "receive every check"
 // sentinel: the dashboard slider only emits 5/10/20/30/50, so a stored value of
 // MAX_TARGET_DAILY_VOTES unambiguously marks a receive-all checker. 100 is a
-// practical stand-in for "all" — exceeding it daily is unlikely.
+// practical stand-in for "all" — exceeding it daily is unlikely. The initial
+// distributor honours the sentinel: checkers at this value are always included,
+// even in the out-of-window top-N phase (see findTopNCheckersWithBudget).
 export const MAX_TARGET_DAILY_VOTES = 100;

--- a/workers/checkers-db-service/src/do.ts
+++ b/workers/checkers-db-service/src/do.ts
@@ -9,6 +9,7 @@ import {
   ProgrammeAPI,
   VoteAPI,
 } from "@/shared/types/schema";
+import { MAX_TARGET_DAILY_VOTES } from "@/shared/constants";
 
 import { VoteFilter } from "./types";
 
@@ -672,9 +673,6 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         },
         {
           $addFields: {
-            _id: { $toString: "$_id" },
-            currentProgrammeId: { $toString: "$currentProgrammeId" },
-
             dailyAssignmentCount: { $ifNull: ["$dailyAssignmentCount", 0] },
             targetDailyVotes: { $ifNull: ["$targetDailyVotes", 10] },
 
@@ -687,12 +685,27 @@ export class DatabaseDurableObject extends DurableObject<Env> {
           },
         },
         {
-          $sort: {
-            remainingBudget: -1,
+          // "Receive every check" (target == MAX_TARGET_DAILY_VOTES) is a promise
+          // the dashboard makes, so those checkers bypass the top-N competition;
+          // everyone else ranks by remaining budget for the N slots.
+          $facet: {
+            receiveAll: [{ $match: { targetDailyVotes: { $gte: MAX_TARGET_DAILY_VOTES } } }],
+            topN: [
+              { $match: { targetDailyVotes: { $lt: MAX_TARGET_DAILY_VOTES } } },
+              { $sort: { remainingBudget: -1 } },
+              { $limit: limit },
+            ],
           },
         },
+        { $project: { checkers: { $concatArrays: ["$receiveAll", "$topN"] } } },
+        { $unwind: "$checkers" },
+        { $replaceRoot: { newRoot: "$checkers" } },
+        { $project: { remainingBudget: 0 } },
         {
-          $limit: limit,
+          $addFields: {
+            _id: { $toString: "$_id" },
+            currentProgrammeId: { $toString: "$currentProgrammeId" },
+          },
         },
       ];
 

--- a/workers/checkers-webhook-service/src/polls.ts
+++ b/workers/checkers-webhook-service/src/polls.ts
@@ -128,10 +128,22 @@ export async function handlePollWebhook(c: Context<{ Bindings: Env }>) {
 
     const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
 
-    const CANARY_PROBABILITY = 0.3;
+    // Share of polls routed to the new InitialPhaseDistributor. Configured per
+    // environment via the CANARY_PROBABILITY var: 0 disables the canary, 1
+    // routes every poll through it (the graduation setting). Blank counts as
+    // unset, not 0 — Number("") is 0, which would silently disable the canary.
+    const rawProbability = env.CANARY_PROBABILITY?.trim();
+    const parsedProbability = rawProbability ? Number(rawProbability) : NaN;
+    const canaryProbability =
+      Number.isFinite(parsedProbability) && parsedProbability >= 0 && parsedProbability <= 1
+        ? parsedProbability
+        : 0.3;
+    if (rawProbability && canaryProbability !== parsedProbability) {
+      console.warn(`Invalid CANARY_PROBABILITY "${env.CANARY_PROBABILITY}", falling back to 0.3`);
+    }
 
     const distributor =
-      Math.random() < CANARY_PROBABILITY
+      Math.random() < canaryProbability
         ? new InitialPhaseDistributor(env.HOST_URL, bot, env.CHECKERS_DB_SERVICE)
         : new PreviousDistributor(env.HOST_URL, bot, env.CHECKERS_DB_SERVICE);
 

--- a/workers/checkers-webhook-service/worker-configuration.d.ts
+++ b/workers/checkers-webhook-service/worker-configuration.d.ts
@@ -38,6 +38,7 @@ interface Env {
   WHATSAPP_BOT_LINK: string;
   CHECKERS_GROUP_LINK: string;
   ENVIRONMENT?: string;
+  CANARY_PROBABILITY?: string;
   WHATSAPP_ADHOC_MESSAGE_QUEUE: Queue<WhatsAppAdhocMessage>;
   WHATSAPP_MESSAGE_SERVICE: WhatsAppMessageService;
   TYPEFORM_SECRET_TOKEN: string;

--- a/workers/checkers-webhook-service/wrangler.jsonc
+++ b/workers/checkers-webhook-service/wrangler.jsonc
@@ -71,6 +71,7 @@
     "HOST_URL": "https://checkmate-checkers-local.tanbingwen.com",
     "TYPEFORM_URL": "https://better-sg.typeform.com/to/MlihTUDx",
     "WHATSAPP_BOT_LINK": "https://wa.me/15556491968",
+    "CANARY_PROBABILITY": "0.3",
   },
   "env": {
     "staging": {
@@ -86,6 +87,7 @@
         "HOST_URL": "https://checkers.staging.checkmate.sg",
         "TYPEFORM_URL": "https://better-sg.typeform.com/to/mlWViHgR",
         "WHATSAPP_BOT_LINK": "https://ref.staging.checkmate.sg/add",
+        "CANARY_PROBABILITY": "0.3",
       },
       "kv_namespaces": [
         {
@@ -145,6 +147,7 @@
         "HOST_URL": "https://checkers.checkmate.sg",
         "TYPEFORM_URL": "https://better-sg.typeform.com/to/ySRoY4Ms",
         "WHATSAPP_BOT_LINK": "https://ref.checkmate.sg/add",
+        "CANARY_PROBABILITY": "0.3",
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## Summary

Release v1.0.14 — following fast on v1.0.13: honour the "receive every check" sentinel in out-of-window initial distribution (#166), plus a config dial for the distribution canary (#168).

### Fixes
- **Receive-all checkers always included in initial distribution (#166)**: v1.0.13's out-of-window path selected only the top 30 checkers by remaining budget, ignoring the `targetDailyVotes = 100` receive-all sentinel — so a receive-all checker could miss ~9% of checks (out-of-window share × 30% canary × chance of not ranking top-30). Since the release-day backfill put **all 74 active production checkers** on the sentinel, this affected everyone until now. The top-N query now facets receive-all checkers (`>= 100`, guarding legacy docs above the cap) past the top-N competition; everyone else ranks by remaining budget exactly as before, and the daily cap still applies at 100.

### Changes
- **Canary probability now configurable (#168)**: the 30% split between the new and previous distributor is read from a `CANARY_PROBABILITY` env var (0 = off, 1 = full rollout) instead of being hardcoded. All environments pinned to "0.3" — no behaviour change until the dial is turned. Invalid/blank values fall back to 0.3 with a logged warning. Smoke-tested in staging post-deploy.

### Tooling / docs
- Seed script gains a receive-all synthetic group so the sentinel path stays testable in staging
- Known Issues documents the redistribution-overshoot trade-off (top-ups can exceed a personal target when every under-target checker has already seen the poll)

## Urgency

v1.0.13 is live in production with the gap active: ~30% of off-peak checks currently go to only 30 of the 74 receive-all checkers at initial distribution. Nothing breaks — redistribution still tops polls up — but until this merges, "receive every check" is not literally true. Recommend merging promptly and holding the community announcement until this is deployed.

## Test plan

- [x] Unit tests pass (137/137); db-service bundles cleanly
- [x] Staging verification with seeded checkers: out-of-window canary assigned exactly 33 (top 30 + 3 receive-all), all receive-all checkers present in assignment contexts, budget cutoff and at-cap exclusion intact, full-distribution arm unchanged at 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
