### PR TITLE
chore: make canary probability configurable via CANARY_PROBABILITY var

### DIFF
--- a/workers/checkers-webhook-service/src/polls.ts
+++ b/workers/checkers-webhook-service/src/polls.ts
@@ -128,10 +128,22 @@ export async function handlePollWebhook(c: Context<{ Bindings: Env }>) {
 
     const bot = new Bot(env.TELEGRAM_BOT_TOKEN);
 
-    const CANARY_PROBABILITY = 0.3;
+    // Share of polls routed to the new InitialPhaseDistributor. Configured per
+    // environment via the CANARY_PROBABILITY var: 0 disables the canary, 1
+    // routes every poll through it (the graduation setting). Blank counts as
+    // unset, not 0 — Number("") is 0, which would silently disable the canary.
+    const rawProbability = env.CANARY_PROBABILITY?.trim();
+    const parsedProbability = rawProbability ? Number(rawProbability) : NaN;
+    const canaryProbability =
+      Number.isFinite(parsedProbability) && parsedProbability >= 0 && parsedProbability <= 1
+        ? parsedProbability
+        : 0.3;
+    if (rawProbability && canaryProbability !== parsedProbability) {
+      console.warn(`Invalid CANARY_PROBABILITY "${env.CANARY_PROBABILITY}", falling back to 0.3`);
+    }
 
     const distributor =
-      Math.random() < CANARY_PROBABILITY
+      Math.random() < canaryProbability
         ? new InitialPhaseDistributor(env.HOST_URL, bot, env.CHECKERS_DB_SERVICE)
         : new PreviousDistributor(env.HOST_URL, bot, env.CHECKERS_DB_SERVICE);
 

--- a/workers/checkers-webhook-service/worker-configuration.d.ts
+++ b/workers/checkers-webhook-service/worker-configuration.d.ts
@@ -38,6 +38,7 @@ interface Env {
   WHATSAPP_BOT_LINK: string;
   CHECKERS_GROUP_LINK: string;
   ENVIRONMENT?: string;
+  CANARY_PROBABILITY?: string;
   WHATSAPP_ADHOC_MESSAGE_QUEUE: Queue<WhatsAppAdhocMessage>;
   WHATSAPP_MESSAGE_SERVICE: WhatsAppMessageService;
   TYPEFORM_SECRET_TOKEN: string;

--- a/workers/checkers-webhook-service/wrangler.jsonc
+++ b/workers/checkers-webhook-service/wrangler.jsonc
@@ -71,6 +71,7 @@
     "HOST_URL": "https://checkmate-checkers-local.tanbingwen.com",
     "TYPEFORM_URL": "https://better-sg.typeform.com/to/MlihTUDx",
     "WHATSAPP_BOT_LINK": "https://wa.me/15556491968",
+    "CANARY_PROBABILITY": "0.3",
   },
   "env": {
     "staging": {
@@ -86,6 +87,7 @@
         "HOST_URL": "https://checkers.staging.checkmate.sg",
         "TYPEFORM_URL": "https://better-sg.typeform.com/to/mlWViHgR",
         "WHATSAPP_BOT_LINK": "https://ref.staging.checkmate.sg/add",
+        "CANARY_PROBABILITY": "0.3",
       },
       "kv_namespaces": [
         {
@@ -145,6 +147,7 @@
         "HOST_URL": "https://checkers.checkmate.sg",
         "TYPEFORM_URL": "https://better-sg.typeform.com/to/ySRoY4Ms",
         "WHATSAPP_BOT_LINK": "https://ref.checkmate.sg/add",
+        "CANARY_PROBABILITY": "0.3",
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## Summary

The 30% canary split between `InitialPhaseDistributor` and `PreviousDistributor` was a hardcoded constant in the poll webhook, meaning any rollout ramp (30% → 50% → 100%), staging pinning, or emergency canary-off required a code deploy. It's now read from a `CANARY_PROBABILITY` env var:

- **0** = canary off (all polls use the previous distributor)
- **1** = full rollout / graduation setting (all polls use the new distributor)
- Invalid or blank values fall back to **0.3** with a logged warning — and blank deliberately counts as *unset*, not 0, since `Number("") === 0` would otherwise silently disable the canary if someone blanked the var in the dashboard
- All three environments (`local`/`staging`/`production`) are pinned to `"0.3"` in `wrangler.jsonc`, so **behaviour is unchanged** until someone turns the dial

Notes:
- Staging can now be pinned to `"1"` when testing the new distributor (during the receive-all verification we had to fire polls repeatedly just to draw the canary arm)
- The eventual canary graduation still ends with a small code-deletion PR; this just makes every step before that config-only
- `worker-configuration.d.ts` got a one-line hand edit matching its existing style — a full `wrangler types` regeneration churns ~11k lines with the current wrangler version, deliberately avoided here

## Test plan

- [x] Unit tests pass (137/137); worker bundles cleanly with the var visible in the dry-run binding list
- [x] Parse edge cases traced in review: unset → 0.3, blank → 0.3, `"0"` → off, `"1"` → always-on (correct against `Math.random()`'s [0,1) range), `"30"`/`"abc"` → 0.3 + warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)