### PR TITLE
fix: select distribution checkers by isOnboardingComplete, not onboardingStatus

### DIFF
--- a/tests/unit/dailyAssignmentReset.test.ts
+++ b/tests/unit/dailyAssignmentReset.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { runDailyAssignmentReset } from "../../workers/checkers-event-handler-service/src/handlers/scheduled/dailyAssignment";
+
+const mockUpdateManyCheckers = vi.fn();
+
+const mockEnv = {
+  CHECKERS_DB_SERVICE: {
+    updateManyCheckers: mockUpdateManyCheckers,
+  },
+} as unknown as Env;
+
+describe("runDailyAssignmentReset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resets counts for checkers selected by isOnboardingComplete, not onboardingStatus", async () => {
+    // Regression guard for the v1.0.13 incident: selecting on
+    // onboardingStatus: "completed" silently dropped legacy checkers whose
+    // docs carry statuses like "number" or "offboarded" while
+    // isOnboardingComplete is true.
+    mockUpdateManyCheckers.mockResolvedValue({ success: true, modifiedCount: 77 });
+
+    await runDailyAssignmentReset(mockEnv);
+
+    expect(mockUpdateManyCheckers).toHaveBeenCalledExactlyOnceWith(
+      { isActive: true, isOnboardingComplete: true },
+      { $set: { dailyAssignmentCount: 0 } }
+    );
+    const [filter] = mockUpdateManyCheckers.mock.calls[0];
+    expect(filter).not.toHaveProperty("onboardingStatus");
+  });
+
+  it("logs and returns on failure without reporting success", async () => {
+    mockUpdateManyCheckers.mockResolvedValue({ success: false, error: "boom" });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await runDailyAssignmentReset(mockEnv);
+
+    expect(errorSpy).toHaveBeenCalledWith("failed to reset daily assignment:", "boom");
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("successfully reset daily assignment")
+    );
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+});

--- a/workers/checkers-db-service/src/do.ts
+++ b/workers/checkers-db-service/src/do.ts
@@ -599,7 +599,10 @@ export class DatabaseDurableObject extends DurableObject<Env> {
       const pollObjectId = new ObjectId(pollId);
 
       const pipeline = [
-        { $match: { isActive: true, onboardingStatus: "completed" } },
+        // Select on isOnboardingComplete, not onboardingStatus: legacy docs carry
+        // statuses like "number"/"offboarded" while still being fully onboarded,
+        // and reactivation only restores isActive (2026-07 distribution incident).
+        { $match: { isActive: true, isOnboardingComplete: true } },
         {
           $lookup: {
             from: "votes",
@@ -662,7 +665,8 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         {
           $match: {
             isActive: true,
-            onboardingStatus: "completed",
+            // isOnboardingComplete, not onboardingStatus — see findCheckersForRedistribution note.
+            isOnboardingComplete: true,
             $expr: {
               $lt: [
                 { $ifNull: ["$dailyAssignmentCount", 0] },
@@ -736,7 +740,8 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         {
           $match: {
             isActive: true,
-            onboardingStatus: "completed",
+            // isOnboardingComplete, not onboardingStatus — see findCheckersForRedistribution note.
+            isOnboardingComplete: true,
             $expr: {
               $lt: [
                 { $ifNull: ["$dailyAssignmentCount", 0] },

--- a/workers/checkers-event-handler-service/src/handlers/scheduled/dailyAssignment.ts
+++ b/workers/checkers-event-handler-service/src/handlers/scheduled/dailyAssignment.ts
@@ -3,7 +3,7 @@ import type { HandlerResult } from "../../types";
 export async function runDailyAssignmentReset(env: Env) {
   console.log("resetting daily assignment for all checkers");
   const result = await env.CHECKERS_DB_SERVICE.updateManyCheckers(
-    { isActive: true, onboardingStatus: "completed" },
+    { isActive: true, isOnboardingComplete: true },
     {
       $set: {
         dailyAssignmentCount: 0,
@@ -12,6 +12,7 @@ export async function runDailyAssignmentReset(env: Env) {
   );
   if (!result.success) {
     console.error("failed to reset daily assignment:", result.error);
+    return;
   }
   console.log(`successfully reset daily assignment for ${result.modifiedCount} checkers`);
 }


### PR DESCRIPTION
## Summary
- Restores the pre-v1.0.13 checker-selection semantics (`isActive: true, isOnboardingComplete: true`) in the three checkers-db-service pipelines (`findCheckersForRedistribution`, `findTopNCheckersWithBudget`, `findCheckersWithBudget`) and the daily assignment-count reset.
- The v1.0.13 queries filtered on `onboardingStatus: "completed"` instead. Six active checkers carry legacy statuses (`offboarded` ×3, `number` ×2, `name` ×1) with `isOnboardingComplete: true`, and silently stopped receiving polls when v1.0.13 deployed on 2026-07-19 (they received polls through 07-18; zero vote assignments across all 8 polls on 07-23). The Telegram reactivate button also only restores `isActive`, so any programme-offboarded checker who reactivates lands in the excluded state.
- The daily reset uses the same restored filter so these checkers' `dailyAssignmentCount` resets again at midnight SGT.
- Also: the reset handler no longer logs a success line after a failed update.

## Fixes
- 6 active checkers (incl. Bw) receiving no polls since the v1.0.13 release despite `isActive: true`.

## Test plan
- [x] `pnpm test` — 139/139 passing, including a new regression test pinning the reset filter to `isOnboardingComplete` and asserting no `onboardingStatus` key.
- [ ] After staging deploy: seed a checker with `onboardingStatus: "offboarded", isOnboardingComplete: true, isActive: true` (scripts/seed-synthetic-checkers.js) and confirm it receives the next poll via the webhook smoke test.
- [ ] After production deploy: confirm the 6 affected checkers appear in the next poll's assignments (expect ~75–76 assignments, up from 69–70).

Follow-ups (not in this PR): decide whether the reactivate button should restore `onboardingStatus`, and whether legacy `number`/`name` docs should be normalised to `completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)