### PR TITLE
fix: address PR review findings on the FAQ bot

### DIFF
--- a/.github/workflows/deploy_workers.yml
+++ b/.github/workflows/deploy_workers.yml
@@ -54,12 +54,23 @@ jobs:
               WORKER_DIRS="$ALL_WORKER_DIRS"
             else
               WORKER_CHANGES=$(echo "$CHANGED_FILES" | grep "^workers/" || true)
-              if [[ -z "$WORKER_CHANGES" ]]; then
+
+              # parameters/faqs.json is bundled into the chat-management worker as
+              # a fallback, so editing it must redeploy that worker or the bundled
+              # copy silently drifts from the checked-in one.
+              FAQ_CHANGES=$(echo "$CHANGED_FILES" | grep "^parameters/faqs.json" || true)
+
+              if [[ -z "$WORKER_CHANGES" && -z "$FAQ_CHANGES" ]]; then
                 echo "No worker changes detected"
                 echo "worker-dirs=[]" >> $GITHUB_OUTPUT
                 exit 0
               fi
-              WORKER_DIRS=$(echo "$WORKER_CHANGES" | grep -o "workers/[^/]*" | cut -d'/' -f2 | sort | uniq | jq -R -s -c 'split("\n") | map(select(length > 0))')
+
+              DIRS=$(echo "$WORKER_CHANGES" | grep -o "workers/[^/]*" | cut -d'/' -f2 || true)
+              if [[ -n "$FAQ_CHANGES" ]]; then
+                DIRS=$(printf '%s\ncheckers-chat-management-service' "$DIRS")
+              fi
+              WORKER_DIRS=$(echo "$DIRS" | sort | uniq | jq -R -s -c 'split("\n") | map(select(length > 0))')
             fi
           fi
 

--- a/tests/unit/faqResolveOutcome.test.ts
+++ b/tests/unit/faqResolveOutcome.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveOutcome } from "../../workers/checkers-chat-management-service/src/classify";
+import type {
+  FaqMatch,
+  QuestionAssessment,
+} from "../../workers/checkers-chat-management-service/src/types";
+
+const THRESHOLD = 0.75;
+
+function assessment(overrides: Partial<QuestionAssessment> = {}): QuestionAssessment {
+  return { isQuestion: true, alreadyAnswered: false, ...overrides };
+}
+
+function match(overrides: Partial<FaqMatch> = {}): FaqMatch {
+  return { faqId: "volunteer-hours", confidence: 0.95, answer: "Some answer.", ...overrides };
+}
+
+describe("resolveOutcome", () => {
+  it("answers a confident match on an unanswered question", () => {
+    expect(resolveOutcome(assessment(), match(), THRESHOLD)).toBe("answered");
+  });
+
+  it("short-circuits on not-a-question before looking at any match", () => {
+    // Chatter must never reach stage 2, so a match object here is irrelevant.
+    expect(resolveOutcome(assessment({ isQuestion: false }), match(), THRESHOLD)).toBe(
+      "not-a-question"
+    );
+  });
+
+  it("prefers human-answered over any FAQ match", () => {
+    // A colleague getting there first outranks the bot having an answer ready.
+    expect(resolveOutcome(assessment({ alreadyAnswered: true }), match(), THRESHOLD)).toBe(
+      "human-answered"
+    );
+  });
+
+  it("treats a null match as no-match, not as an error", () => {
+    // matchFaq returns null only on transient failure; the caller decides whether
+    // to retry. Here we assert the mapping is no-match rather than throwing.
+    expect(resolveOutcome(assessment(), null, THRESHOLD)).toBe("no-match");
+  });
+
+  it("treats an explicit none as no-match", () => {
+    expect(resolveOutcome(assessment(), match({ faqId: "none", answer: "" }), THRESHOLD)).toBe(
+      "no-match"
+    );
+  });
+
+  it("treats a matched id with an empty answer as no-match", () => {
+    expect(resolveOutcome(assessment(), match({ answer: "" }), THRESHOLD)).toBe("no-match");
+  });
+
+  it("holds back a match below the threshold", () => {
+    expect(resolveOutcome(assessment(), match({ confidence: 0.5 }), THRESHOLD)).toBe(
+      "low-confidence"
+    );
+  });
+
+  it("treats confidence exactly at the threshold as good enough", () => {
+    // The sweep compares with <, so equality answers. Pinned because moving this
+    // boundary silently changes how often the bot speaks.
+    expect(resolveOutcome(assessment(), match({ confidence: THRESHOLD }), THRESHOLD)).toBe(
+      "answered"
+    );
+  });
+
+  it("honours a threshold raised in KV above the code default", () => {
+    // The eval endpoint reads the same KV value as the sweep; this is the case
+    // that used to diverge when dev.ts hardcoded the default.
+    expect(resolveOutcome(assessment(), match({ confidence: 0.8 }), 0.9)).toBe("low-confidence");
+  });
+});

--- a/workers/checkers-chat-management-service/src/classify.ts
+++ b/workers/checkers-chat-management-service/src/classify.ts
@@ -144,6 +144,29 @@ function extractToolArguments(response: unknown): Record<string, unknown> | null
   return args && typeof args === "object" ? (args as Record<string, unknown>) : null;
 }
 
+/**
+ * The outcome a candidate resolves to, given both stages and the threshold.
+ *
+ * Shared so the eval endpoint cannot drift from what the cron would actually
+ * decide — the two used to branch identically in two places, and dev.ts had
+ * already diverged by reading the code default instead of the live KV value.
+ *
+ * A null `match` means stage 2 either did not run or produced nothing usable;
+ * both resolve to no-match here. Whether a null is worth retrying is the
+ * caller's decision, not this function's.
+ */
+export function resolveOutcome(
+  assessment: QuestionAssessment,
+  match: FaqMatch | null,
+  threshold: number
+): "not-a-question" | "human-answered" | "no-match" | "low-confidence" | "answered" {
+  if (!assessment.isQuestion) return "not-a-question";
+  if (assessment.alreadyAnswered) return "human-answered";
+  if (!match || match.faqId === "none" || !match.answer) return "no-match";
+  if (match.confidence < threshold) return "low-confidence";
+  return "answered";
+}
+
 /** Attempts per stage, including the first. Workers AI returns transient 3xxx errors. */
 const MAX_ATTEMPTS = 3;
 
@@ -277,10 +300,13 @@ export async function matchFaq(
   const faqId = typeof args.faq_id === "string" ? args.faq_id : "none";
 
   // Guard against a hallucinated id: only ids we actually supplied may be acted on.
+  // Returned as an explicit no-match rather than null, because null means
+  // "transient failure, retry" — and a hallucination is not transient. Returning
+  // null here would re-classify the same message every sweep for FAQ_MAX_AGE_HOURS.
   const known = faqId === "none" || faqs.some(faq => faq.id === faqId);
   if (!known) {
-    console.error(`Model returned unknown faq_id "${faqId}"; treating as no match`);
-    return null;
+    console.error(`Model returned unknown faq_id "${faqId}"; recording as no match`);
+    return { faqId: "none", confidence: 0, answer: "" };
   }
 
   return {

--- a/workers/checkers-chat-management-service/src/dev.ts
+++ b/workers/checkers-chat-management-service/src/dev.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
-import { PARAMETER_DEFAULTS } from "@/shared/helpers/parameters";
-import { assessQuestion, matchFaq } from "./classify";
+import { getParameters } from "@/shared/helpers/parameters";
+import { assessQuestion, matchFaq, resolveOutcome } from "./classify";
 import { loadFaqs } from "./faq";
 import type { FollowingMessage } from "./types";
 
@@ -51,27 +51,22 @@ export async function handleEvalRequest(c: Context<{ Bindings: Env }>) {
     return c.json({ error: "Stage 1 failed; see worker logs" }, 502);
   }
 
-  // Mirrors the sweep's short-circuit exactly, so what you see here is what the
-  // cron would have done with the same message.
-  if (!assessment.isQuestion) {
-    return c.json({ stage1: assessment, outcome: "not-a-question", stage2: null });
-  }
-  if (assessment.alreadyAnswered) {
-    return c.json({ stage1: assessment, outcome: "human-answered", stage2: null });
-  }
+  // Same threshold source as the sweep, so the eval reflects what the cron
+  // would decide rather than what the code default says.
+  const { FAQ_CONFIDENCE_THRESHOLD } = await getParameters(env.CHECKMATE_CHECKERS_PARAMETERS_KV, [
+    "FAQ_CONFIDENCE_THRESHOLD",
+  ]);
 
-  const match = await matchFaq(env, body.message, faqs);
-  if (!match) {
+  // Stage 2 only runs for genuine unanswered questions, exactly as in the sweep.
+  const needsFaq = assessment.isQuestion && !assessment.alreadyAnswered;
+  const match = needsFaq ? await matchFaq(env, body.message, faqs) : null;
+  if (needsFaq && !match) {
     return c.json({ error: "Stage 2 failed; see worker logs" }, 502);
   }
 
-  const threshold = PARAMETER_DEFAULTS.FAQ_CONFIDENCE_THRESHOLD; // KV value wins in the sweep
-  const outcome =
-    match.faqId === "none" || !match.answer
-      ? "no-match"
-      : match.confidence < threshold
-        ? "low-confidence"
-        : "answered";
-
-  return c.json({ stage1: assessment, outcome, stage2: match });
+  return c.json({
+    stage1: assessment,
+    outcome: resolveOutcome(assessment, match, FAQ_CONFIDENCE_THRESHOLD),
+    stage2: match,
+  });
 }

--- a/workers/checkers-chat-management-service/src/sweep.ts
+++ b/workers/checkers-chat-management-service/src/sweep.ts
@@ -1,6 +1,6 @@
 import { Bot } from "grammy";
 import { getParameters } from "@/shared/helpers/parameters";
-import { assessQuestion, matchFaq } from "./classify";
+import { assessQuestion, matchFaq, resolveOutcome } from "./classify";
 import { loadFaqs } from "./faq";
 import type { CandidateMessage, FollowingMessage } from "./types";
 
@@ -104,14 +104,13 @@ export async function runFaqSweep(env: Env): Promise<void> {
       continue;
     }
 
-    if (!assessment.isQuestion) {
-      await markProcessed(env, chatId, candidate.messageId, "not-a-question");
-      continue;
-    }
-
-    if (assessment.alreadyAnswered) {
-      console.log(`Message ${candidate.messageId} was already answered by a human`);
-      await markProcessed(env, chatId, candidate.messageId, "human-answered");
+    // resolveOutcome is shared with the eval endpoint so the two cannot diverge.
+    const earlyOutcome = resolveOutcome(assessment, null, params.FAQ_CONFIDENCE_THRESHOLD);
+    if (earlyOutcome === "not-a-question" || earlyOutcome === "human-answered") {
+      if (earlyOutcome === "human-answered") {
+        console.log(`Message ${candidate.messageId} was already answered by a human`);
+      }
+      await markProcessed(env, chatId, candidate.messageId, earlyOutcome);
       continue;
     }
 
@@ -130,22 +129,34 @@ export async function runFaqSweep(env: Env): Promise<void> {
 
     if (!verdict) continue;
 
-    if (verdict.faqId === "none" || !verdict.answer) {
-      await markProcessed(env, chatId, candidate.messageId, "no-match");
-      continue;
-    }
-
-    if (verdict.confidence < params.FAQ_CONFIDENCE_THRESHOLD) {
-      console.log(
-        `Below threshold (${verdict.confidence.toFixed(2)} < ${params.FAQ_CONFIDENCE_THRESHOLD}) ` +
-          `for message ${candidate.messageId}, matched "${verdict.faqId}"`
-      );
-      await markProcessed(env, chatId, candidate.messageId, "low-confidence");
+    const outcome = resolveOutcome(assessment, verdict, params.FAQ_CONFIDENCE_THRESHOLD);
+    if (outcome !== "answered") {
+      if (outcome === "low-confidence") {
+        console.log(
+          `Below threshold (${verdict.confidence.toFixed(2)} < ${params.FAQ_CONFIDENCE_THRESHOLD}) ` +
+            `for message ${candidate.messageId}, matched "${verdict.faqId}"`
+        );
+      }
+      await markProcessed(env, chatId, candidate.messageId, outcome);
       continue;
     }
 
     if (answeredFaqIds.has(verdict.faqId)) {
       await markProcessed(env, chatId, candidate.messageId, "duplicate", verdict.faqId);
+      continue;
+    }
+
+    // Shadow mode logs without claiming. Claiming here would mark the message
+    // answered when nothing was posted, so it would never be reconsidered once
+    // shadow mode is turned off — which matters because this var is the kill
+    // switch: everything asked during an incident would be silently swallowed.
+    if (shadowMode) {
+      console.log(
+        `[shadow] would reply to ${candidate.messageId} (@${candidate.userName}) ` +
+          `via "${verdict.faqId}" @ ${verdict.confidence.toFixed(2)}: ${verdict.answer}`
+      );
+      answeredFaqIds.add(verdict.faqId);
+      repliesPosted += 1;
       continue;
     }
 
@@ -169,14 +180,6 @@ export async function runFaqSweep(env: Env): Promise<void> {
     }
     answeredFaqIds.add(verdict.faqId);
     repliesPosted += 1;
-
-    if (shadowMode) {
-      console.log(
-        `[shadow] would reply to ${candidate.messageId} (@${candidate.userName}) ` +
-          `via "${verdict.faqId}" @ ${verdict.confidence.toFixed(2)}: ${verdict.answer}`
-      );
-      continue;
-    }
 
     try {
       await bot!.api.sendMessage(chatId, verdict.answer, {


### PR DESCRIPTION
Addresses the four findings from the automated review on #172. All were verified against the code before fixing; all four were real.

## 1. Shadow mode claimed messages it never answered

`markProcessed(..., "answered", ...)` ran **before** the shadow-mode branch, so a "would reply" was permanently recorded as answered with nothing posted.

The analytics corruption is the obvious cost. The sharper one: `FAQ_SHADOW_MODE` is the only kill switch, so flipping it on during an incident would have silently swallowed every question asked in that window — none of them re-selected after flipping it back. The shadow branch now logs and continues without claiming.

## 2. A hallucinated `faq_id` caused endless re-classification

`matchFaq` returned `null` for an unknown id — the same value it returns for a transient gateway failure — and the sweep treats `null` as retryable. One such message would be re-classified on every sweep for up to `FAQ_MAX_AGE_HOURS` (~46 runs, both stages).

Now returns an explicit no-match, which is what the comment already claimed it did. `null` keeps its single meaning: retry.

## 3. Outcome branching duplicated, and already diverged

The is-question / already-answered / no-match / low-confidence chain existed verbatim in `sweep.ts` and `dev.ts`. They had already drifted: `dev.ts` used `PARAMETER_DEFAULTS.FAQ_CONFIDENCE_THRESHOLD` while the sweep read the live KV value, so the eval endpoint could disagree with the cron for the same message.

Extracted `resolveOutcome(assessment, match, threshold)`, called by both, and `dev.ts` now reads the same KV parameter. 9 new tests pin the behaviour, including the `<` threshold boundary and the KV-override case that used to diverge.

## 4. The `parameters/faqs.json` deploy trigger was a no-op

Adding it to `on.push.paths` fired the workflow, but change detection only maps `^shared/` and `^workers/` to worker directories — so a push touching only that file yielded `worker-dirs=[]` and deployed nothing. Since `faq.ts` bundles the file as a fallback, the deployed copy would silently drift from the checked-in one. Change detection now maps it to `checkers-chat-management-service`, unioned with any `workers/` matches.

## Test plan

- [x] `pnpm test` — 168 passing (9 new).
- [x] Typecheck clean.
- [x] `wrangler deploy --dry-run` for staging and production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)